### PR TITLE
Add roslyn_get_callers tool for call hierarchy analysis

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,6 +351,7 @@ gh pr status
 | `roslyn_get_projects_in_build_order` | Loads a solution and returns projects in build order (dependencies first) |
 | `roslyn_find_symbol` | Semantic search for types, methods, properties by name pattern |
 | `roslyn_get_references` | Find all references to a symbol at a given position |
+| `roslyn_get_callers` | Find all callers of a method (only call sites, not declarations) |
 | `roslyn_get_implementations` | Find all implementations of an interface or derived classes |
 | `roslyn_get_type_members` | Get all members (methods, properties, fields, events) of a type |
 | `roslyn_get_method_body` | Get full source code of a specific method |
@@ -452,6 +453,52 @@ Finds all references to a symbol at a given file position. Essential for impact 
   ]
 }
 ```
+
+### roslyn_get_callers
+
+Finds all callers of a method at a given position. Unlike `roslyn_get_references`, this returns only actual call sites - not declarations, docs, mocks, or type references. Essential for understanding execution flow and impact analysis before refactoring.
+
+**Input:**
+```json
+{
+  "solutionPath": "C:\\path\\to\\solution.sln",
+  "filePath": "C:\\path\\to\\UserRepository.cs",
+  "line": 25,
+  "column": 17,
+  "maxResults": 100,
+  "offset": 0,
+  "projectFilter": "MyApp.*",
+  "fileFilter": "*Service.cs"
+}
+```
+
+**Parameters:**
+- `solutionPath` (required) - Absolute path to .sln file
+- `filePath` (required) - Absolute path to the source file containing the method
+- `line` (required) - Line number (1-based) where the method is located
+- `column` (required) - Column number (1-based) where the method is located
+- `maxResults` - Maximum callers to return (default: 100, max: 1000)
+- `offset` - Skip first N results for pagination (default: 0)
+- `projectFilter` - Filter by project name, supports wildcards (`*`)
+- `fileFilter` - Filter by file path, supports wildcards (`*`)
+
+**Output (compact):**
+```json
+{
+  "success": true,
+  "symbol": "UserRepository.Save(User)",
+  "totalCallers": 47,
+  "returnedCount": 47,
+  "callers": [
+    { "file": "Services\\UserService.cs", "line": 67, "method": "CreateUser", "type": "UserService" },
+    { "file": "Jobs\\ImportJob.cs", "line": 112, "method": "ProcessBatch", "type": "ImportJob" }
+  ]
+}
+```
+
+**When to use `roslyn_get_callers` vs `roslyn_get_references`:**
+- **`roslyn_get_callers`**: When you need to know who CALLS a method (execution flow, impact analysis)
+- **`roslyn_get_references`**: When you need ALL mentions (including declarations, docs, interface definitions)
 
 ### roslyn_get_implementations
 
@@ -932,7 +979,7 @@ private static void RegisterYourTool(McpServer server)
 ## Roadmap
 
 ### High Priority Tools
-- [ ] `roslyn_get_call_hierarchy` - Find callers of a method + what it calls (impact analysis)
+- [x] `roslyn_get_callers` - Find callers of a method (impact analysis) ✓ Implemented
 - [ ] `roslyn_extract_method` - Extract code block into new method
 - [ ] `roslyn_change_signature` - Add/remove/reorder parameters with auto-fix callers
 - [ ] `roslyn_get_document_symbols` - All symbols in a specific file

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Or manually copy `CLAUDE_TEMPLATE.md` from this repository and customize it for 
 |------|-------------|
 | `roslyn_find_symbol` | Search for types, methods, properties by name pattern |
 | `roslyn_get_references` | Find all usages of a symbol across the solution |
+| `roslyn_get_callers` | Find all callers of a method (only call sites, not declarations) |
 | `roslyn_get_implementations` | Find all implementations of an interface or derived classes |
 | `roslyn_get_type_members` | List all members (methods, properties, fields) of a type |
 | `roslyn_get_method_body` | Get the full source code of a specific method |
@@ -401,7 +402,7 @@ The server uses:
 
 | Tool | Description | Use Case |
 |------|-------------|----------|
-| `roslyn_get_call_hierarchy` | Find callers of a method + what it calls | Impact analysis before changes |
+| ~~`roslyn_get_callers`~~ | ~~Find callers of a method~~ | ✓ Implemented |
 | `roslyn_extract_method` | Extract code block into new method | Refactoring large methods |
 | `roslyn_change_signature` | Add/remove/reorder parameters | API changes with auto-fix callers |
 | `roslyn_get_document_symbols` | All symbols in a specific file | Quick file overview |

--- a/RoslynMcpServer.Tests/Services/GetCallersTests.cs
+++ b/RoslynMcpServer.Tests/Services/GetCallersTests.cs
@@ -1,0 +1,99 @@
+namespace RoslynMcpServer.Tests.Services;
+
+/// <summary>
+/// Tests for the roslyn_get_callers functionality.
+/// </summary>
+public class GetCallersTests
+{
+    /// <summary>
+    /// Tests that GetCallersAsync returns error for non-existent solution.
+    /// Issue: #7
+    /// </summary>
+    [Fact]
+    public async Task GetCallersAsync_WithInvalidSolution_ReturnsError()
+    {
+        // Arrange
+        var service = new SolutionAnalyzerService();
+        var fakePath = @"C:\nonexistent\fake.sln";
+
+        // Act
+        var result = await service.GetCallersAsync(
+            fakePath,
+            @"C:\some\file.cs",
+            line: 10,
+            column: 5);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Contains("not found", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Tests that GetCallersAsync returns error for non-existent file.
+    /// Issue: #7
+    /// </summary>
+    [Fact]
+    public async Task GetCallersAsync_WithInvalidFile_ReturnsError()
+    {
+        // Arrange
+        var service = new SolutionAnalyzerService();
+        var solutionPath = Path.GetFullPath(
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "RoslynMcpServer.slnx"));
+
+        // Act
+        var result = await service.GetCallersAsync(
+            solutionPath,
+            @"C:\nonexistent\file.cs",
+            line: 10,
+            column: 5);
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Contains("not found", result.Error, StringComparison.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// Tests that CallerInfo has required compact properties.
+    /// Issue: #7
+    /// </summary>
+    [Fact]
+    public void CallerInfo_HasCompactProperties()
+    {
+        // Arrange & Act
+        var caller = new CallerInfo
+        {
+            File = "test.cs",
+            Line = 42,
+            Method = "DoWork"
+        };
+
+        // Assert
+        Assert.Equal("test.cs", caller.File);
+        Assert.Equal(42, caller.Line);
+        Assert.Equal("DoWork", caller.Method);
+        Assert.Null(caller.Type); // Optional field
+    }
+
+    /// <summary>
+    /// Tests that GetCallersResult includes pagination info.
+    /// Issue: #7
+    /// </summary>
+    [Fact]
+    public void GetCallersResult_IncludesPaginationFields()
+    {
+        // Arrange & Act
+        var result = new GetCallersResult
+        {
+            Success = true,
+            Symbol = "MyClass.MyMethod()",
+            TotalCallers = 100,
+            ReturnedCount = 50,
+            Callers = []
+        };
+
+        // Assert
+        Assert.True(result.Success);
+        Assert.Equal(100, result.TotalCallers);
+        Assert.Equal(50, result.ReturnedCount);
+    }
+}

--- a/src/Models.Symbols.cs
+++ b/src/Models.Symbols.cs
@@ -157,3 +157,59 @@ public class MemberInfo
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public string? InheritedFrom { get; init; }
 }
+
+/// <summary>
+/// Result of finding callers of a method.
+/// </summary>
+public class GetCallersResult
+{
+    public bool Success { get; init; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Error { get; init; }
+
+    /// <summary>
+    /// The symbol signature (e.g., "UserRepository.Save(User)").
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Symbol { get; init; }
+
+    /// <summary>
+    /// Total number of callers found (before pagination).
+    /// </summary>
+    public int TotalCallers { get; init; }
+
+    /// <summary>
+    /// Number of callers returned in this response.
+    /// </summary>
+    public int ReturnedCount { get; init; }
+
+    public List<CallerInfo> Callers { get; init; } = [];
+}
+
+/// <summary>
+/// Information about a caller location. Compact format for large result sets.
+/// </summary>
+public class CallerInfo
+{
+    /// <summary>
+    /// File path (relative when possible).
+    /// </summary>
+    public required string File { get; init; }
+
+    /// <summary>
+    /// Line number of the call.
+    /// </summary>
+    public int Line { get; init; }
+
+    /// <summary>
+    /// Name of the method containing the call.
+    /// </summary>
+    public required string Method { get; init; }
+
+    /// <summary>
+    /// Name of the type containing the calling method.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Type { get; init; }
+}

--- a/src/RoslynTools.Callers.cs
+++ b/src/RoslynTools.Callers.cs
@@ -1,0 +1,157 @@
+using System.Text.Json;
+
+namespace RoslynMcpServer;
+
+public static partial class RoslynTools
+{
+    /// <summary>
+    /// Finds all callers of a method at a given position.
+    /// </summary>
+    private static void RegisterGetCallersTool(McpServer server)
+    {
+        server.RegisterTool(
+            "roslyn_get_callers",
+            new ToolDefinition
+            {
+                Description = "Finds all callers of a method/property at a given file position. Unlike get_references, this returns only actual call sites - not declarations, docs, or type references. Essential for understanding execution flow and impact analysis before refactoring.",
+                InputSchema = new
+                {
+                    type = "object",
+                    properties = new
+                    {
+                        solutionPath = new
+                        {
+                            type = "string",
+                            description = "Absolute path to the .sln or .slnx solution file"
+                        },
+                        filePath = new
+                        {
+                            type = "string",
+                            description = "Absolute path to the source file containing the method"
+                        },
+                        line = new
+                        {
+                            type = "integer",
+                            description = "Line number (1-based) where the method is located",
+                            minimum = 1
+                        },
+                        column = new
+                        {
+                            type = "integer",
+                            description = "Column number (1-based) where the method is located",
+                            minimum = 1
+                        },
+                        maxResults = new
+                        {
+                            type = "integer",
+                            description = "Maximum number of callers to return. Default: 100",
+                            minimum = 1,
+                            maximum = 1000
+                        },
+                        offset = new
+                        {
+                            type = "integer",
+                            description = "Skip first N results for pagination. Default: 0",
+                            minimum = 0
+                        },
+                        projectFilter = new
+                        {
+                            type = "string",
+                            description = "Filter by project name. Supports wildcards (*). Example: 'MyApp.*'"
+                        },
+                        fileFilter = new
+                        {
+                            type = "string",
+                            description = "Filter by file path. Supports wildcards (*). Example: '*Service.cs'"
+                        }
+                    },
+                    required = new[] { "solutionPath", "filePath", "line", "column" }
+                },
+                Annotations = new ToolAnnotations
+                {
+                    ReadOnlyHint = true,
+                    IdempotentHint = true
+                }
+            },
+            async args =>
+            {
+                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var filePath = args?["filePath"]?.GetValue<string>();
+                var line = args?["line"]?.GetValue<int>() ?? 0;
+                var column = args?["column"]?.GetValue<int>() ?? 0;
+
+                if (string.IsNullOrWhiteSpace(solutionPath))
+                {
+                    return new
+                    {
+                        content = new[]
+                        {
+                            new { type = "text", text = "Error: solutionPath is required" }
+                        },
+                        isError = true
+                    };
+                }
+
+                if (string.IsNullOrWhiteSpace(filePath))
+                {
+                    return new
+                    {
+                        content = new[]
+                        {
+                            new { type = "text", text = "Error: filePath is required" }
+                        },
+                        isError = true
+                    };
+                }
+
+                if (line < 1)
+                {
+                    return new
+                    {
+                        content = new[]
+                        {
+                            new { type = "text", text = "Error: line must be >= 1" }
+                        },
+                        isError = true
+                    };
+                }
+
+                if (column < 1)
+                {
+                    return new
+                    {
+                        content = new[]
+                        {
+                            new { type = "text", text = "Error: column must be >= 1" }
+                        },
+                        isError = true
+                    };
+                }
+
+                // Parse optional parameters
+                var maxResults = args?["maxResults"]?.GetValue<int>() ?? 100;
+                var offset = args?["offset"]?.GetValue<int>() ?? 0;
+                var projectFilter = args?["projectFilter"]?.GetValue<string>();
+                var fileFilter = args?["fileFilter"]?.GetValue<string>();
+
+                var result = await _analyzerService!.GetCallersAsync(
+                    solutionPath,
+                    filePath,
+                    line,
+                    column,
+                    maxResults,
+                    offset,
+                    projectFilter,
+                    fileFilter);
+
+                return new
+                {
+                    content = new[]
+                    {
+                        new { type = "text", text = JsonSerializer.Serialize(result, JsonOptions) }
+                    },
+                    isError = !result.Success
+                };
+            });
+    }
+}

--- a/src/RoslynTools.cs
+++ b/src/RoslynTools.cs
@@ -28,6 +28,7 @@ public static partial class RoslynTools
         RegisterGetProjectsInBuildOrderTool(server);
         RegisterFindSymbolTool(server);
         RegisterGetReferencesTool(server);
+        RegisterGetCallersTool(server);
         RegisterGetImplementationsTool(server);
         RegisterGetTypeMembersTool(server);
         RegisterGetMethodBodyTool(server);

--- a/src/SolutionAnalyzerService.Callers.cs
+++ b/src/SolutionAnalyzerService.Callers.cs
@@ -1,0 +1,209 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.MSBuild;
+
+namespace RoslynMcpServer;
+
+public partial class SolutionAnalyzerService
+{
+    /// <summary>
+    /// Finds all callers of a method at the given position.
+    /// Unlike FindReferences, this returns only actual call sites, not declarations or other references.
+    /// </summary>
+    public async Task<GetCallersResult> GetCallersAsync(
+        string solutionPath,
+        string filePath,
+        int line,
+        int column,
+        int maxResults = 100,
+        int offset = 0,
+        string? projectFilter = null,
+        string? fileFilter = null)
+    {
+        EnsureMSBuildRegistered();
+
+        if (!File.Exists(solutionPath))
+        {
+            return new GetCallersResult
+            {
+                Success = false,
+                Error = $"Solution file not found: {solutionPath}"
+            };
+        }
+
+        if (!File.Exists(filePath))
+        {
+            return new GetCallersResult
+            {
+                Success = false,
+                Error = $"Source file not found: {filePath}"
+            };
+        }
+
+        using var workspace = MSBuildWorkspace.Create();
+        RegisterFailureHandler(workspace);
+
+        try
+        {
+            Console.Error.WriteLine($"Loading solution: {solutionPath}");
+            var solution = await workspace.OpenSolutionAsync(solutionPath);
+
+            // Find the document
+            var normalizedPath = Path.GetFullPath(filePath);
+            var document = solution.Projects
+                .SelectMany(p => p.Documents)
+                .FirstOrDefault(d => string.Equals(
+                    Path.GetFullPath(d.FilePath ?? ""),
+                    normalizedPath,
+                    StringComparison.OrdinalIgnoreCase));
+
+            if (document == null)
+            {
+                return new GetCallersResult
+                {
+                    Success = false,
+                    Error = $"File not found in solution: {filePath}"
+                };
+            }
+
+            // Get semantic model and find symbol at position
+            var semanticModel = await document.GetSemanticModelAsync();
+            if (semanticModel == null)
+            {
+                return new GetCallersResult
+                {
+                    Success = false,
+                    Error = "Failed to get semantic model"
+                };
+            }
+
+            // Convert 1-based line/column to 0-based position
+            var text = await document.GetTextAsync();
+            var position = text.Lines[line - 1].Start + (column - 1);
+
+            var symbol = await SymbolFinder.FindSymbolAtPositionAsync(semanticModel, position, workspace);
+
+            if (symbol == null)
+            {
+                return new GetCallersResult
+                {
+                    Success = false,
+                    Error = $"No symbol found at {filePath}:{line}:{column}"
+                };
+            }
+
+            // Only methods, properties, and events can have callers
+            if (symbol is not (IMethodSymbol or IPropertySymbol or IEventSymbol))
+            {
+                return new GetCallersResult
+                {
+                    Success = false,
+                    Error = $"Symbol '{symbol.Name}' is a {symbol.Kind}, not a method/property/event. Only callable symbols have callers."
+                };
+            }
+
+            Console.Error.WriteLine($"Finding callers of: {symbol.ToDisplayString()}");
+
+            // Find all callers
+            var callers = await SymbolFinder.FindCallersAsync(symbol, solution);
+            var callerList = callers.ToList();
+
+            // Flatten to individual call locations
+            var allLocations = new List<(ISymbol CallingSymbol, Location Location, Document Document)>();
+            foreach (var caller in callerList)
+            {
+                foreach (var location in caller.Locations)
+                {
+                    var callerDoc = solution.GetDocument(location.SourceTree);
+                    if (callerDoc != null)
+                    {
+                        allLocations.Add((caller.CallingSymbol, location, callerDoc));
+                    }
+                }
+            }
+
+            // Apply project filter
+            if (!string.IsNullOrEmpty(projectFilter))
+            {
+                allLocations = allLocations
+                    .Where(loc => MatchesPattern(loc.Document.Project.Name, projectFilter))
+                    .ToList();
+            }
+
+            // Apply file filter
+            if (!string.IsNullOrEmpty(fileFilter))
+            {
+                allLocations = allLocations
+                    .Where(loc => MatchesPattern(loc.Document.FilePath ?? "", fileFilter))
+                    .ToList();
+            }
+
+            var totalAfterFilters = allLocations.Count;
+
+            // Sort by file path, then line
+            allLocations = allLocations
+                .OrderBy(loc => loc.Document.FilePath)
+                .ThenBy(loc => loc.Location.GetLineSpan().StartLinePosition.Line)
+                .ToList();
+
+            // Apply pagination
+            var paginatedLocations = allLocations
+                .Skip(offset)
+                .Take(maxResults)
+                .ToList();
+
+            // Build compact result list
+            var solutionDir = Path.GetDirectoryName(solutionPath) ?? "";
+            var results = new List<CallerInfo>();
+
+            foreach (var (callingSymbol, location, callerDoc) in paginatedLocations)
+            {
+                var lineSpan = location.GetLineSpan();
+                var callerFilePath = callerDoc.FilePath ?? "unknown";
+
+                // Make path relative if possible
+                var displayPath = callerFilePath.StartsWith(solutionDir, StringComparison.OrdinalIgnoreCase)
+                    ? callerFilePath[(solutionDir.Length + 1)..]
+                    : callerFilePath;
+
+                results.Add(new CallerInfo
+                {
+                    File = displayPath,
+                    Line = lineSpan.StartLinePosition.Line + 1,
+                    Method = callingSymbol.Name,
+                    Type = callingSymbol.ContainingType?.Name
+                });
+            }
+
+            Console.Error.WriteLine($"Found {totalAfterFilters} callers (returning {results.Count})");
+
+            // Build symbol signature
+            var symbolSignature = symbol.ContainingType != null
+                ? $"{symbol.ContainingType.Name}.{symbol.Name}"
+                : symbol.Name;
+
+            if (symbol is IMethodSymbol method)
+            {
+                var paramTypes = string.Join(", ", method.Parameters.Select(p => p.Type.Name));
+                symbolSignature += $"({paramTypes})";
+            }
+
+            return new GetCallersResult
+            {
+                Success = true,
+                Symbol = symbolSignature,
+                TotalCallers = totalAfterFilters,
+                ReturnedCount = results.Count,
+                Callers = results
+            };
+        }
+        catch (Exception ex)
+        {
+            return new GetCallersResult
+            {
+                Success = false,
+                Error = $"Failed to find callers: {ex.Message}"
+            };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add `roslyn_get_callers` tool to find all callers of a method
- Unlike `roslyn_get_references`, returns only actual call sites (not declarations, docs, mocks)
- Compact output format optimized for large solutions
- Pagination support (maxResults, offset) for solutions with many callers

## Implementation
- `GetCallersResult` and `CallerInfo` DTOs
- `SolutionAnalyzerService.GetCallersAsync` using Roslyn's `SymbolFinder.FindCallersAsync`
- Tool registration with full parameter support

## Test plan
- [x] Unit tests pass: `dotnet test`
- [x] Build succeeds: `dotnet build`
- [ ] Manual test on real solution

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)