### PR TITLE
Fix false positive errors for WPF/XAML projects

### DIFF
--- a/src/SolutionAnalyzerService.AddMember.cs
+++ b/src/SolutionAnalyzerService.AddMember.cs
@@ -37,8 +37,7 @@ public partial class SolutionAnalyzerService
             };
         }
 
-        using var workspace = MSBuildWorkspace.Create();
-        RegisterFailureHandler(workspace);
+        using var workspace = CreateWorkspace();
 
         try
         {

--- a/src/SolutionAnalyzerService.BatchCodeFix.cs
+++ b/src/SolutionAnalyzerService.BatchCodeFix.cs
@@ -41,8 +41,7 @@ public partial class SolutionAnalyzerService
             };
         }
 
-        using var workspace = MSBuildWorkspace.Create();
-        RegisterFailureHandler(workspace);
+        using var workspace = CreateWorkspace();
 
         try
         {

--- a/src/SolutionAnalyzerService.Callers.cs
+++ b/src/SolutionAnalyzerService.Callers.cs
@@ -40,8 +40,7 @@ public partial class SolutionAnalyzerService
             };
         }
 
-        using var workspace = MSBuildWorkspace.Create();
-        RegisterFailureHandler(workspace);
+        using var workspace = CreateWorkspace();
 
         try
         {

--- a/src/SolutionAnalyzerService.CodeFix.cs
+++ b/src/SolutionAnalyzerService.CodeFix.cs
@@ -46,8 +46,7 @@ public partial class SolutionAnalyzerService
             };
         }
 
-        using var workspace = MSBuildWorkspace.Create();
-        RegisterFailureHandler(workspace);
+        using var workspace = CreateWorkspace();
 
         try
         {

--- a/src/SolutionAnalyzerService.Diagnostics.cs
+++ b/src/SolutionAnalyzerService.Diagnostics.cs
@@ -31,8 +31,7 @@ public partial class SolutionAnalyzerService
             };
         }
 
-        using var workspace = MSBuildWorkspace.Create();
-        RegisterFailureHandler(workspace);
+        using var workspace = CreateWorkspace();
 
         try
         {

--- a/src/SolutionAnalyzerService.Implementations.cs
+++ b/src/SolutionAnalyzerService.Implementations.cs
@@ -26,8 +26,7 @@ public partial class SolutionAnalyzerService
             };
         }
 
-        using var workspace = MSBuildWorkspace.Create();
-        RegisterFailureHandler(workspace);
+        using var workspace = CreateWorkspace();
 
         try
         {

--- a/src/SolutionAnalyzerService.MethodBody.cs
+++ b/src/SolutionAnalyzerService.MethodBody.cs
@@ -27,8 +27,7 @@ public partial class SolutionAnalyzerService
             };
         }
 
-        using var workspace = MSBuildWorkspace.Create();
-        RegisterFailureHandler(workspace);
+        using var workspace = CreateWorkspace();
 
         try
         {

--- a/src/SolutionAnalyzerService.References.cs
+++ b/src/SolutionAnalyzerService.References.cs
@@ -59,8 +59,7 @@ public partial class SolutionAnalyzerService
             };
         }
 
-        using var workspace = MSBuildWorkspace.Create();
-        RegisterFailureHandler(workspace);
+        using var workspace = CreateWorkspace();
 
         try
         {

--- a/src/SolutionAnalyzerService.Rename.cs
+++ b/src/SolutionAnalyzerService.Rename.cs
@@ -37,8 +37,7 @@ public partial class SolutionAnalyzerService
             };
         }
 
-        using var workspace = MSBuildWorkspace.Create();
-        RegisterFailureHandler(workspace);
+        using var workspace = CreateWorkspace();
 
         try
         {

--- a/src/SolutionAnalyzerService.Symbols.cs
+++ b/src/SolutionAnalyzerService.Symbols.cs
@@ -28,8 +28,7 @@ public partial class SolutionAnalyzerService
             };
         }
 
-        using var workspace = MSBuildWorkspace.Create();
-        RegisterFailureHandler(workspace);
+        using var workspace = CreateWorkspace();
 
         try
         {

--- a/src/SolutionAnalyzerService.TypeMembers.cs
+++ b/src/SolutionAnalyzerService.TypeMembers.cs
@@ -27,8 +27,7 @@ public partial class SolutionAnalyzerService
             };
         }
 
-        using var workspace = MSBuildWorkspace.Create();
-        RegisterFailureHandler(workspace);
+        using var workspace = CreateWorkspace();
 
         try
         {

--- a/src/SolutionAnalyzerService.UpdateMethod.cs
+++ b/src/SolutionAnalyzerService.UpdateMethod.cs
@@ -29,8 +29,7 @@ public partial class SolutionAnalyzerService
             };
         }
 
-        using var workspace = MSBuildWorkspace.Create();
-        RegisterFailureHandler(workspace);
+        using var workspace = CreateWorkspace();
 
         try
         {

--- a/src/SolutionAnalyzerService.cs
+++ b/src/SolutionAnalyzerService.cs
@@ -42,6 +42,27 @@ public partial class SolutionAnalyzerService
     }
 
     /// <summary>
+    /// Creates an MSBuildWorkspace configured for WPF/XAML projects.
+    /// This ensures XAML-generated code (InitializeComponent, x:Name fields) is included in compilation.
+    /// </summary>
+    public static MSBuildWorkspace CreateWorkspace()
+    {
+        // Configure workspace with design-time build properties
+        // This tells MSBuild to evaluate projects as Visual Studio would,
+        // including XAML compilation which generates *.g.cs files
+        var properties = new Dictionary<string, string>
+        {
+            { "DesignTimeBuild", "true" },
+            { "BuildingInsideVisualStudio", "true" },
+            { "ProvideCommandLineArgs", "true" }
+        };
+
+        var workspace = MSBuildWorkspace.Create(properties);
+        RegisterFailureHandler(workspace);
+        return workspace;
+    }
+
+    /// <summary>
     /// Loads a solution and returns projects in build order (dependencies first).
     /// </summary>
     public async Task<ProjectBuildOrderResult> GetProjectsInBuildOrderAsync(string solutionPath)
@@ -57,8 +78,7 @@ public partial class SolutionAnalyzerService
             };
         }
 
-        using var workspace = MSBuildWorkspace.Create();
-        RegisterFailureHandler(workspace);
+        using var workspace = CreateWorkspace();
 
         try
         {


### PR DESCRIPTION
## Summary
- Add `CreateWorkspace()` helper method that configures MSBuildWorkspace with design-time build properties
- Update all 13 `MSBuildWorkspace.Create()` calls to use the new helper

## Problem
WPF projects reported false positive errors like:
- CS0103: The name 'InitializeComponent' does not exist
- CS0103: The name 'uxMap' does not exist (for x:Name elements)

## Solution
Configure workspace with properties that enable XAML compilation:
```csharp
{ "DesignTimeBuild", "true" }
{ "BuildingInsideVisualStudio", "true" }
{ "ProvideCommandLineArgs", "true" }
```

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)