### PR TITLE
Feature: Add instruction templates and dynamic instructions via MCP

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -395,6 +395,8 @@ gh pr status
 | `roslyn_apply_code_fix` | Apply Roslyn's suggested fix for a single diagnostic |
 | `roslyn_batch_apply_code_fixes` | Batch apply fixes for all diagnostics of a specific type |
 | `roslyn_rename_symbol` | Rename a symbol across the entire solution with all references |
+| `roslyn_get_template` | Get a CLAUDE.md template for C# projects |
+| `roslyn_get_instructions` | Get development instructions for a specific topic |
 
 ### roslyn_find_symbol
 
@@ -950,6 +952,65 @@ Renames a symbol (type, method, property, field, parameter, variable) at a speci
 1. Use `roslyn_find_symbol` to locate the symbol you want to rename
 2. Call `roslyn_rename_symbol` with the file path, line, column, and new name
 3. The tool applies the rename immediately and returns affected files
+
+### roslyn_get_template
+
+Returns a CLAUDE.md template for C# projects. Users can copy this to their project root.
+
+**Input:**
+```json
+{
+  "template": "standard"
+}
+```
+
+**Parameters:**
+- `template` (required) - Template type:
+  - `minimal` - Basic MCP pointers only
+  - `standard` - Code + git workflow instructions
+  - `tdd` - Test-driven development workflow
+  - `team` - Full team workflow with issue-first development
+
+**Output:**
+```json
+{
+  "template": "standard",
+  "availableTemplates": ["minimal", "standard", "tdd", "team"],
+  "content": "# CLAUDE.md - C# Development...",
+  "usage": "Copy the content above to a CLAUDE.md file in your project root."
+}
+```
+
+### roslyn_get_instructions
+
+Returns specific development instructions on-demand. Called when a project's CLAUDE.md directs to get instructions for a topic.
+
+**Input:**
+```json
+{
+  "topic": "code"
+}
+```
+
+**Parameters:**
+- `topic` (required) - Topic to get instructions for:
+  - `code` - C# best practices, tool preferences
+  - `git` - Issue-first workflow, branch naming, commit format
+  - `tdd` - Test-driven development workflow
+  - `pre-pr` - Checklist before creating a pull request
+  - `tools` - Full Roslyn MCP tool preferences table
+
+**Output:**
+Returns the instructions as markdown text, ready to follow.
+
+**Usage:**
+Project CLAUDE.md files can be minimal - just pointing to these instructions:
+```markdown
+Before modifying C# code: roslyn_get_instructions(topic: "code")
+Before git operations: roslyn_get_instructions(topic: "git")
+```
+
+This keeps instructions up-to-date with the MCP server version.
 
 ## Key Concepts
 

--- a/CLAUDE_TEMPLATE.md
+++ b/CLAUDE_TEMPLATE.md
@@ -1,7 +1,26 @@
 # CLAUDE.md Template for C# Projects
 
-> **Copy this file to your project root as `CLAUDE.md`** and customize it for your codebase.
-> Delete this intro section after copying.
+> **Setup Instructions:**
+> 1. Copy this file to your project root as `CLAUDE.md`
+> 2. Customize the "Project Overview" section
+> 3. Choose your workflow template (see below)
+> 4. Delete this intro section
+
+---
+
+## Quick Setup (Recommended)
+
+Instead of manually maintaining instructions, use the Roslyn MCP server to get up-to-date guidance:
+
+```bash
+# Get a template suited to your workflow
+roslyn_get_template(template: "standard")   # Basic workflow
+roslyn_get_template(template: "tdd")        # Test-driven development
+roslyn_get_template(template: "team")       # Full team workflow with issues
+roslyn_get_template(template: "minimal")    # Just MCP pointers
+```
+
+Copy the returned content to your CLAUDE.md.
 
 ---
 
@@ -9,126 +28,34 @@
 
 ## Project Overview
 
-<!-- Customize this section for your project -->
-Brief description of what this project does and its purpose.
+<!-- Customize: Brief description of what this project does -->
 
-## Tool Preferences for C# Code
+## Tool Preferences
 
-When working with C# files in .NET solutions, **PREFER Roslyn MCP tools over native tools**:
+When working with C# files in .NET solutions, use Roslyn MCP tools.
 
-| Task | Use This | NOT This |
-|------|----------|----------|
-| Find a type/method | `roslyn_find_symbol` | `Grep` or `Glob` |
-| Understand a class | `roslyn_get_type_members` | `Read` the whole file |
-| Read a method | `roslyn_get_method_body` | `Read` the whole file |
-| Edit a method | `roslyn_update_method` | `Edit` with text patterns |
-| Add a member | `roslyn_add_member` | `Edit` to insert code |
-| Find all references | `roslyn_get_references` | `Grep` for text |
-| Find callers only | `roslyn_get_callers` | `roslyn_get_references` (includes non-calls) |
-| Find implementations | `roslyn_get_implementations` | `Grep` for class names |
-| Check for errors | `roslyn_get_diagnostics` | `Bash` dotnet build |
-| Fix one warning | `roslyn_apply_code_fix` | Manual `Edit` |
-| Fix many warnings | `roslyn_batch_apply_code_fixes` | Loop of single fixes |
-| Rename symbol | `roslyn_rename_symbol` | Manual find/replace |
+For full tool preferences: `roslyn_get_instructions(topic: "tools")`
 
-**Why Roslyn tools?**
-- **Semantic understanding** - Knows the difference between `class User` and variable `user`
-- **Precise edits** - Updates exactly one method without pattern ambiguity
-- **Type-aware** - Finds all implementations of an interface, not just text matches
-- **Overload handling** - Distinguishes `Save()` from `Save(bool force)`
+## Development Workflows
 
-**Only use native tools for:**
-- Non-C# files (JSON, XML, markdown, .csproj)
-- Creating brand new .cs files (use `Write`, then `roslyn_add_member` to populate)
-- Very small files (< 100 lines) where `Read`/`Edit` is simpler
-- When Roslyn MCP server is not connected
-
-## Code Guidelines
-
-### File Size
-- **Keep .cs files under 300 lines.** Large files are hard to maintain and slow to analyze.
-- Before splitting, think about proper refactoring:
-  1. Extract helper classes or utilities (prefer composition)
-  2. Apply SOLID principles (Single Responsibility, etc.)
-  3. Use partial classes only as a last resort when logic truly belongs together
-
-### C# Best Practices
-- Use modern C# features (primary constructors, collection expressions, pattern matching)
-- Prefer `required` properties over constructor parameters for DTOs
-- Use `async/await` for all I/O operations
-- Error messages should be actionable (tell the user what to do)
-
-### Avoid Over-Engineering
-- Only make changes that are directly requested or clearly necessary
-- Don't add features, refactor code, or make "improvements" beyond what was asked
-- A bug fix doesn't need surrounding code cleaned up
-- Don't add error handling for scenarios that can't happen
-- Three similar lines of code is better than a premature abstraction
-
-## Test Driven Development (Recommended)
-
-Follow TDD for reliable code changes:
-
-### TDD Workflow
+Before modifying C# code:
 ```
-1. Write FAILING test(s) first
-2. Run tests - verify they FAIL
-3. Write minimum code to make tests PASS
-4. Refactor if needed (tests must still pass)
-5. Commit
+roslyn_get_instructions(topic: "code")
 ```
 
-### Test Naming Convention
-```csharp
-// Format: MethodName_Scenario_ExpectedResult
-[Fact]
-public void CalculateTotal_WithEmptyCart_ReturnsZero()
-
-[Fact]
-public async Task SaveAsync_WhenDatabaseUnavailable_ThrowsException()
+Before git operations (issues, branches, commits, PRs):
+```
+roslyn_get_instructions(topic: "git")
 ```
 
-### Running Tests
-```bash
-# Run all tests
-dotnet test
-
-# Run specific test class
-dotnet test --filter "FullyQualifiedName~MyServiceTests"
-
-# Run with coverage
-dotnet test --collect:"XPlat Code Coverage"
+Before creating a pull request:
+```
+roslyn_get_instructions(topic: "pre-pr")
 ```
 
-## Common Workflows
-
-### Understanding a Large Class
+For test-driven development workflow:
 ```
-1. roslyn_get_type_members(typeName: "MyClass") → see all members
-2. roslyn_get_method_body(typeName: "MyClass", methodName: "DoWork") → read specific method
-3. Make targeted changes with roslyn_update_method
-```
-
-### Impact Analysis Before Refactoring
-```
-1. roslyn_find_symbol(pattern: "MyMethod") → find the method
-2. roslyn_get_callers(filePath, line, column) → see who CALLS this method
-3. Assess impact - these callers need updating if you change the signature
-```
-
-**Note:** Use `roslyn_get_callers` for call sites only. Use `roslyn_get_references` when you need ALL mentions (including declarations, docs, interface definitions).
-
-### Fixing Compiler Warnings
-```
-1. roslyn_get_diagnostics(severityFilter: "warning") → see all warnings
-2. roslyn_get_diagnostics(diagnosticId: "CS8618") → get details for specific warning
-3. roslyn_batch_apply_code_fixes(diagnosticId: "CS8618") → auto-fix all instances
-```
-
-### Safe Rename
-```
-1. roslyn_find_symbol(pattern: "OldName") → locate the symbol
-2. roslyn_rename_symbol(newName: "NewName") → rename everywhere
+roslyn_get_instructions(topic: "tdd")
 ```
 
 ## Project Structure
@@ -147,14 +74,9 @@ YourProject/
 ## Build Commands
 
 ```bash
-# Build
-dotnet build
-
-# Run tests
-dotnet test
-
-# Run the application
-dotnet run --project src/YourProject
+dotnet build        # Build
+dotnet test         # Run tests
+dotnet run          # Run the application
 ```
 
 <!-- Add any project-specific commands here -->

--- a/src/Instructions.cs
+++ b/src/Instructions.cs
@@ -1,0 +1,350 @@
+namespace RoslynMcpServer;
+
+/// <summary>
+/// Contains embedded instruction content for CLAUDE.md templates and topic-specific guidance.
+/// Issue: #15
+/// </summary>
+public static class Instructions
+{
+    #region Templates
+
+    public static class Templates
+    {
+        public const string Minimal = """
+            # CLAUDE.md - C# Development with Roslyn MCP
+
+            When working with C# code, use the Roslyn MCP server for guidance:
+
+            - Before modifying C# code: `roslyn_get_instructions(topic: "code")`
+            - Before git operations: `roslyn_get_instructions(topic: "git")`
+            - Before creating PR: `roslyn_get_instructions(topic: "pre-pr")`
+
+            Use Roslyn MCP tools (`roslyn_*`) instead of native tools (Grep, Read, Edit) for C# files.
+            """;
+
+        public const string Standard = """
+            # CLAUDE.md - C# Development with Roslyn MCP
+
+            ## Tool Preferences
+
+            When working with C# files in .NET solutions, prefer Roslyn MCP tools over native tools:
+
+            | Task | Use This | Not This |
+            |------|----------|----------|
+            | Find type/method | `roslyn_find_symbol` | Grep |
+            | Read a method | `roslyn_get_method_body` | Read entire file |
+            | Edit a method | `roslyn_update_method` | Edit with text patterns |
+            | Find references | `roslyn_get_references` | Grep for text |
+            | Check errors | `roslyn_get_diagnostics` | dotnet build |
+
+            For full tool preferences: `roslyn_get_instructions(topic: "tools")`
+
+            ## Workflows
+
+            - Before modifying C# code: `roslyn_get_instructions(topic: "code")`
+            - Before git operations: `roslyn_get_instructions(topic: "git")`
+            - Before creating PR: `roslyn_get_instructions(topic: "pre-pr")`
+            """;
+
+        public const string Tdd = """
+            # CLAUDE.md - C# Development with Roslyn MCP (TDD)
+
+            ## Test-Driven Development
+
+            **YOU MUST follow TDD for ALL code changes. No exceptions.**
+
+            1. Write FAILING test(s) first
+            2. Run tests - verify they FAIL
+            3. Write minimum code to make tests PASS
+            4. Refactor if needed (tests must still pass)
+
+            For full TDD workflow: `roslyn_get_instructions(topic: "tdd")`
+
+            ## Tool Preferences
+
+            When working with C# files, prefer Roslyn MCP tools:
+
+            | Task | Use This | Not This |
+            |------|----------|----------|
+            | Find type/method | `roslyn_find_symbol` | Grep |
+            | Read a method | `roslyn_get_method_body` | Read entire file |
+            | Edit a method | `roslyn_update_method` | Edit with text patterns |
+            | Check errors | `roslyn_get_diagnostics` | dotnet build |
+
+            For full tool preferences: `roslyn_get_instructions(topic: "tools")`
+
+            ## Workflows
+
+            - Before modifying C# code: `roslyn_get_instructions(topic: "code")`
+            - Before git operations: `roslyn_get_instructions(topic: "git")`
+            - Before creating PR: `roslyn_get_instructions(topic: "pre-pr")`
+            """;
+
+        public const string Team = """
+            # CLAUDE.md - C# Development with Roslyn MCP (Team Workflow)
+
+            ## Issue-First Development
+
+            **NEVER write code without a GitHub issue.**
+
+            1. Create GitHub issue first describing the feature/bug
+            2. Create feature branch: `issues/N`
+            3. Reference issue in commits: `Fixes #N`
+
+            For full git workflow: `roslyn_get_instructions(topic: "git")`
+
+            ## Test-Driven Development
+
+            **YOU MUST follow TDD for ALL code changes.**
+
+            For full TDD workflow: `roslyn_get_instructions(topic: "tdd")`
+
+            ## Tool Preferences
+
+            When working with C# files, prefer Roslyn MCP tools:
+
+            | Task | Use This | Not This |
+            |------|----------|----------|
+            | Find type/method | `roslyn_find_symbol` | Grep |
+            | Read a method | `roslyn_get_method_body` | Read entire file |
+            | Edit a method | `roslyn_update_method` | Edit with text patterns |
+            | Check errors | `roslyn_get_diagnostics` | dotnet build |
+
+            For full tool preferences: `roslyn_get_instructions(topic: "tools")`
+
+            ## Workflows
+
+            - Before modifying C# code: `roslyn_get_instructions(topic: "code")`
+            - Before git operations: `roslyn_get_instructions(topic: "git")`
+            - Before creating PR: `roslyn_get_instructions(topic: "pre-pr")`
+            """;
+
+        public static string? Get(string templateName) => templateName.ToLowerInvariant() switch
+        {
+            "minimal" => Minimal,
+            "standard" => Standard,
+            "tdd" => Tdd,
+            "team" => Team,
+            _ => null
+        };
+
+        public static string[] Available => ["minimal", "standard", "tdd", "team"];
+    }
+
+    #endregion
+
+    #region Topics
+
+    public static class Topics
+    {
+        public const string Code = """
+            # C# Code Modification Guidelines
+
+            ## Before Modifying Code
+
+            1. **NEVER propose changes to code you haven't read.** Use `roslyn_get_method_body` first.
+            2. **Understand existing patterns** before suggesting modifications.
+            3. **Keep files under 300 lines.** Extract helper classes if needed.
+
+            ## Tool Preferences
+
+            | Task | Use This | Not This |
+            |------|----------|----------|
+            | Find a type/method | `roslyn_find_symbol` | Grep or Glob |
+            | Understand a class | `roslyn_get_type_members` | Read the whole file |
+            | Read a method | `roslyn_get_method_body` | Read the whole file |
+            | Edit a method | `roslyn_update_method` | Edit with text patterns |
+            | Add a member | `roslyn_add_member` | Edit to insert code |
+            | Find all references | `roslyn_get_references` | Grep for text |
+            | Find callers only | `roslyn_get_callers` | roslyn_get_references |
+            | Find implementations | `roslyn_get_implementations` | Grep for class names |
+            | Check for errors | `roslyn_get_diagnostics` | dotnet build |
+            | Fix one warning | `roslyn_apply_code_fix` | Manual Edit |
+            | Fix many warnings | `roslyn_batch_apply_code_fixes` | Loop of single fixes |
+            | Rename symbol | `roslyn_rename_symbol` | Manual find/replace |
+
+            ## Code Quality
+
+            - Use async/await for all I/O operations
+            - Error messages should be actionable
+            - Avoid over-engineering - only make changes that are directly requested
+            - Don't add features, refactor code, or make "improvements" beyond what was asked
+            """;
+
+        public const string Git = """
+            # Git Workflow Guidelines
+
+            ## Issue-First Development
+
+            **Create a GitHub issue BEFORE making code changes.**
+
+            ```bash
+            gh issue create --title "Brief description" --body "Details" --label "bug|enhancement"
+            ```
+
+            ## Branch Naming
+
+            - Feature branches: `issues/N` (where N is the issue number)
+            - Base all work on the default RC branch
+
+            ## Commit Messages
+
+            ```
+            Fix: description of change
+
+            Fixes #N
+
+            Co-Authored-By: Claude <noreply@anthropic.com>
+            ```
+
+            ## Workflow
+
+            1. Create GitHub issue
+            2. Create branch: `git checkout -b issues/N`
+            3. Make changes with TDD
+            4. Verify build: `roslyn_get_diagnostics`
+            5. Commit with issue reference
+            6. Push and create PR: `gh pr create --base rc/X.X.X`
+
+            ## Safety Rules
+
+            - NEVER use `git push --force` on main/master
+            - NEVER use `git commit --amend` unless explicitly requested
+            - NEVER skip hooks (`--no-verify`)
+            """;
+
+        public const string Tdd = """
+            # Test-Driven Development Guidelines
+
+            ## TDD Workflow
+
+            1. **Write FAILING test(s) first** - with issue reference comment
+            2. **Run tests** - verify they FAIL
+            3. **Write minimum code** to make tests PASS
+            4. **Refactor** if needed (tests must still pass)
+            5. **Commit**
+
+            ## Test Naming Convention
+
+            ```csharp
+            // Format: MethodName_Scenario_ExpectedResult
+            [Fact]
+            public void FindSymbols_WithValidPattern_ReturnsMatchingSymbols()
+            ```
+
+            ## Test Comment Format (Required)
+
+            ```csharp
+            /// <summary>
+            /// Tests that FindSymbols returns matching symbols for a valid pattern.
+            /// Issue: #42
+            /// </summary>
+            [Fact]
+            public void FindSymbols_WithValidPattern_ReturnsMatchingSymbols()
+            {
+                // Arrange
+                // Act
+                // Assert
+            }
+            ```
+
+            ## Running Tests
+
+            ```bash
+            dotnet test                           # Run all tests
+            dotnet test --filter "Name~MyTest"    # Run specific test
+            ```
+            """;
+
+        public const string PrePr = """
+            # Pre-Pull Request Checklist
+
+            ## Before Creating a PR
+
+            1. **Verify build has no errors:**
+               ```
+               roslyn_get_diagnostics(severityFilter: "error")
+               ```
+
+            2. **Check for new warnings** (fix if reasonable):
+               ```
+               roslyn_get_diagnostics(severityFilter: "warning")
+               ```
+
+            3. **Run tests:**
+               ```bash
+               dotnet test
+               ```
+
+            4. **Verify all changes are committed:**
+               ```bash
+               git status
+               ```
+
+            5. **Review your changes:**
+               ```bash
+               git diff main...HEAD
+               ```
+
+            ## Creating the PR
+
+            ```bash
+            gh pr create --base rc/X.X.X --title "Fix: description" --body "Fixes #N"
+            ```
+
+            ## PR Body Format
+
+            ```markdown
+            ## Summary
+            - Brief description of changes
+
+            ## Test Plan
+            - [ ] Unit tests pass
+            - [ ] Manual testing done
+
+            Fixes #N
+            ```
+            """;
+
+        public const string Tools = """
+            # Roslyn MCP Tool Preferences
+
+            When working with C# files in .NET solutions, **PREFER Roslyn MCP tools over native tools**:
+
+            | Task | Use This | NOT This |
+            |------|----------|----------|
+            | Find a type/method | `roslyn_find_symbol` | `Grep` or `Glob` |
+            | Understand a class | `roslyn_get_type_members` | `Read` the whole file |
+            | Read a method | `roslyn_get_method_body` | `Read` the whole file |
+            | Edit a method | `roslyn_update_method` | `Edit` with text patterns |
+            | Add a member | `roslyn_add_member` | `Edit` to insert code |
+            | Find all references | `roslyn_get_references` | `Grep` for text |
+            | Find callers only | `roslyn_get_callers` | `roslyn_get_references` (includes non-calls) |
+            | Find implementations | `roslyn_get_implementations` | `Grep` for class names |
+            | Check for errors | `roslyn_get_diagnostics` | `Bash` dotnet build |
+            | Fix one warning | `roslyn_apply_code_fix` | Manual `Edit` |
+            | Fix many warnings | `roslyn_batch_apply_code_fixes` | Loop of single fixes |
+            | Rename symbol | `roslyn_rename_symbol` | Manual find/replace |
+
+            **Only use native tools for:**
+            - Non-C# files (JSON, XML, markdown, .csproj)
+            - Creating brand new .cs files (use `Write`, then `roslyn_add_member`)
+            - Very small files (< 100 lines) where `Read`/`Edit` is simpler
+            - When Roslyn MCP server is not connected
+            """;
+
+        public static string? Get(string topicName) => topicName.ToLowerInvariant() switch
+        {
+            "code" => Code,
+            "git" => Git,
+            "tdd" => Tdd,
+            "pre-pr" or "prepr" or "pr" => PrePr,
+            "tools" => Tools,
+            _ => null
+        };
+
+        public static string[] Available => ["code", "git", "tdd", "pre-pr", "tools"];
+    }
+
+    #endregion
+}

--- a/src/RoslynTools.Instructions.cs
+++ b/src/RoslynTools.Instructions.cs
@@ -1,0 +1,133 @@
+using System.Text.Json;
+
+namespace RoslynMcpServer;
+
+/// <summary>
+/// MCP tools for serving development instructions and templates.
+/// Issue: #15
+/// </summary>
+public static partial class RoslynTools
+{
+    /// <summary>
+    /// Returns a CLAUDE.md template for users to copy to their project.
+    /// </summary>
+    private static void RegisterGetTemplateTool(McpServer server)
+    {
+        server.RegisterTool(
+            "roslyn_get_template",
+            new ToolDefinition
+            {
+                Description = "Returns a CLAUDE.md template for C# development. Users copy this to their project. Templates include instructions to call roslyn_get_instructions for detailed guidance.",
+                InputSchema = new
+                {
+                    type = "object",
+                    properties = new
+                    {
+                        template = new
+                        {
+                            type = "string",
+                            description = "Template type: 'minimal' (basic MCP pointers), 'standard' (code + git), 'tdd' (test-driven), 'team' (full workflow with issues)",
+                            @enum = new[] { "minimal", "standard", "tdd", "team" }
+                        }
+                    },
+                    required = new[] { "template" }
+                },
+                Annotations = new ToolAnnotations
+                {
+                    ReadOnlyHint = true,
+                    IdempotentHint = true
+                }
+            },
+            async args =>
+            {
+                var templateName = args?["template"]?.GetValue<string>()?.ToLowerInvariant() ?? "standard";
+                var template = Instructions.Templates.Get(templateName);
+
+                if (template == null)
+                {
+                    return new
+                    {
+                        content = new[]
+                        {
+                            new { type = "text", text = $"Error: Unknown template '{templateName}'. Available: {string.Join(", ", Instructions.Templates.Available)}" }
+                        },
+                        isError = true
+                    };
+                }
+
+                var result = new
+                {
+                    template = templateName,
+                    availableTemplates = Instructions.Templates.Available,
+                    content = template,
+                    usage = "Copy the content above to a CLAUDE.md file in your project root."
+                };
+
+                return new
+                {
+                    content = new[]
+                    {
+                        new { type = "text", text = JsonSerializer.Serialize(result, JsonOptions) }
+                    }
+                };
+            });
+    }
+
+    /// <summary>
+    /// Returns specific development instructions on-demand.
+    /// </summary>
+    private static void RegisterGetInstructionsTool(McpServer server)
+    {
+        server.RegisterTool(
+            "roslyn_get_instructions",
+            new ToolDefinition
+            {
+                Description = "Returns specific development instructions for C# projects. Call this when the project's CLAUDE.md directs you to get instructions for a topic.",
+                InputSchema = new
+                {
+                    type = "object",
+                    properties = new
+                    {
+                        topic = new
+                        {
+                            type = "string",
+                            description = "Topic: 'code' (C# best practices), 'git' (workflow, branches, commits), 'tdd' (test-driven development), 'pre-pr' (checklist before PR), 'tools' (Roslyn tool preferences)",
+                            @enum = new[] { "code", "git", "tdd", "pre-pr", "tools" }
+                        }
+                    },
+                    required = new[] { "topic" }
+                },
+                Annotations = new ToolAnnotations
+                {
+                    ReadOnlyHint = true,
+                    IdempotentHint = true
+                }
+            },
+            async args =>
+            {
+                var topicName = args?["topic"]?.GetValue<string>()?.ToLowerInvariant() ?? "code";
+                var instructions = Instructions.Topics.Get(topicName);
+
+                if (instructions == null)
+                {
+                    return new
+                    {
+                        content = new[]
+                        {
+                            new { type = "text", text = $"Error: Unknown topic '{topicName}'. Available: {string.Join(", ", Instructions.Topics.Available)}" }
+                        },
+                        isError = true
+                    };
+                }
+
+                // Return just the instructions text directly for easy consumption
+                return new
+                {
+                    content = new[]
+                    {
+                        new { type = "text", text = instructions }
+                    }
+                };
+            });
+    }
+}

--- a/src/RoslynTools.cs
+++ b/src/RoslynTools.cs
@@ -41,6 +41,8 @@ public static partial class RoslynTools
         RegisterGraphStatusTool(server);
         RegisterGraphAnalyzeTool(server);
         RegisterQueryGraphTool(server);
+        RegisterGetTemplateTool(server);
+        RegisterGetInstructionsTool(server);
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Add `roslyn_get_template` tool to return CLAUDE.md templates (minimal, standard, tdd, team)
- Add `roslyn_get_instructions` tool to return topic-specific instructions on-demand
- Update CLAUDE_TEMPLATE.md to use the new dynamic approach
- Update CLAUDE.md with new tools documentation

## Benefits
- Instructions stay up-to-date with MCP server version
- Users only need a minimal CLAUDE.md that points to MCP for instructions
- Different project types can use different templates

## New Tools

### roslyn_get_template
```
roslyn_get_template(template: "standard")
```
Templates: minimal, standard, tdd, team

### roslyn_get_instructions
```
roslyn_get_instructions(topic: "code")
```
Topics: code, git, tdd, pre-pr, tools

## Test Plan
- [x] Build succeeds
- [x] All 44 tests pass

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)