### PR TITLE
Improve instruction content with XML tags and reasoning steps

### DIFF
--- a/src/Instructions.cs
+++ b/src/Instructions.cs
@@ -2,7 +2,8 @@ namespace RoslynMcpServer;
 
 /// <summary>
 /// Contains embedded instruction content for CLAUDE.md templates and topic-specific guidance.
-/// Issue: #15
+/// Uses XML tags and chain-of-thought patterns for improved Claude reasoning.
+/// Issues: #15, #17
 /// </summary>
 public static class Instructions
 {
@@ -138,199 +139,317 @@ public static class Instructions
     public static class Topics
     {
         public const string Code = """
-            # C# Code Modification Guidelines
+            <context>
+            You are modifying C# code in a .NET solution. The Roslyn MCP server provides semantic code analysis tools that are more accurate than text-based search/replace.
+            </context>
 
-            ## Before Modifying Code
+            <critical_rules>
+            - NEVER propose changes to code you haven't read
+            - NEVER use Grep/Glob for C# symbols - use roslyn_find_symbol
+            - NEVER use Read for large files - use roslyn_get_method_body
+            - NEVER use Edit with text patterns - use roslyn_update_method
+            </critical_rules>
 
-            1. **NEVER propose changes to code you haven't read.** Use `roslyn_get_method_body` first.
-            2. **Understand existing patterns** before suggesting modifications.
-            3. **Keep files under 300 lines.** Extract helper classes if needed.
+            <before_any_change>
+            Follow these steps before modifying any C# code:
 
-            ## Tool Preferences
+            1. LOCATE the code:
+               - Use roslyn_find_symbol to find the type/method by name
+               - Note the file path and line number from the result
 
-            | Task | Use This | Not This |
-            |------|----------|----------|
-            | Find a type/method | `roslyn_find_symbol` | Grep or Glob |
-            | Understand a class | `roslyn_get_type_members` | Read the whole file |
-            | Read a method | `roslyn_get_method_body` | Read the whole file |
-            | Edit a method | `roslyn_update_method` | Edit with text patterns |
-            | Add a member | `roslyn_add_member` | Edit to insert code |
-            | Find all references | `roslyn_get_references` | Grep for text |
-            | Find callers only | `roslyn_get_callers` | roslyn_get_references |
-            | Find implementations | `roslyn_get_implementations` | Grep for class names |
-            | Check for errors | `roslyn_get_diagnostics` | dotnet build |
-            | Fix one warning | `roslyn_apply_code_fix` | Manual Edit |
-            | Fix many warnings | `roslyn_batch_apply_code_fixes` | Loop of single fixes |
-            | Rename symbol | `roslyn_rename_symbol` | Manual find/replace |
+            2. UNDERSTAND the code:
+               - Use roslyn_get_type_members to see all members of the class
+               - Use roslyn_get_method_body to read the specific method
+               - Use roslyn_get_callers to understand who calls this code
 
-            ## Code Quality
+            3. VERIFY the scope:
+               - If file > 300 lines, plan to extract helper classes
+               - If method > 50 lines, consider breaking it down
 
-            - Use async/await for all I/O operations
-            - Error messages should be actionable
-            - Avoid over-engineering - only make changes that are directly requested
-            - Don't add features, refactor code, or make "improvements" beyond what was asked
+            4. MAKE the change:
+               - Use roslyn_update_method for existing methods
+               - Use roslyn_add_member for new methods/properties
+               - Use roslyn_rename_symbol for renaming
+
+            5. VERIFY the result:
+               - Use roslyn_get_diagnostics to check for errors
+            </before_any_change>
+
+            <tool_selection>
+            Choose the right tool for each task:
+
+            | When you need to... | Use this tool |
+            |---------------------|---------------|
+            | Find a type or method | roslyn_find_symbol |
+            | See class structure | roslyn_get_type_members |
+            | Read a method | roslyn_get_method_body |
+            | Edit a method | roslyn_update_method |
+            | Add new member | roslyn_add_member |
+            | Find all usages | roslyn_get_references |
+            | Find who calls this | roslyn_get_callers |
+            | Find implementations | roslyn_get_implementations |
+            | Check for errors | roslyn_get_diagnostics |
+            | Fix a warning | roslyn_apply_code_fix |
+            | Fix many warnings | roslyn_batch_apply_code_fixes |
+            | Rename something | roslyn_rename_symbol |
+            </tool_selection>
+
+            <code_quality>
+            - Keep files under 300 lines
+            - Use async/await for I/O operations
+            - Make error messages actionable
+            - Avoid over-engineering - only change what's requested
+            </code_quality>
             """;
 
         public const string Git = """
-            # Git Workflow Guidelines
+            <context>
+            You are performing git operations in a project that follows issue-first development. Every code change must be linked to a GitHub issue.
+            </context>
 
-            ## Issue-First Development
+            <critical_rules>
+            - NEVER write code without a GitHub issue
+            - NEVER use git push --force on main/master
+            - NEVER use git commit --amend unless explicitly requested
+            - NEVER skip hooks (--no-verify)
+            </critical_rules>
 
-            **Create a GitHub issue BEFORE making code changes.**
+            <workflow>
+            Follow these steps for any code change:
 
-            ```bash
-            gh issue create --title "Brief description" --body "Details" --label "bug|enhancement"
+            1. CREATE ISSUE (if not exists):
+               ```bash
+               gh issue create --title "Brief description" --body "Details" --label "bug|enhancement"
+               ```
+               Note the issue number (e.g., #42)
+
+            2. CREATE BRANCH:
+               ```bash
+               git checkout -b issues/42
+               ```
+               Branch name format: issues/N where N is issue number
+
+            3. MAKE CHANGES:
+               - Follow TDD if required (roslyn_get_instructions topic: "tdd")
+               - Use Roslyn tools for C# changes (roslyn_get_instructions topic: "code")
+
+            4. VERIFY BUILD:
+               ```
+               roslyn_get_diagnostics(severityFilter: "error")
+               ```
+
+            5. COMMIT:
+               ```bash
+               git add -A
+               git commit -m "Fix: description
+
+               Fixes #42
+
+               Co-Authored-By: Claude <noreply@anthropic.com>"
+               ```
+
+            6. PUSH AND PR:
+               ```bash
+               git push -u origin issues/42
+               gh pr create --base rc/X.X.X --title "Fix: description" --body "Fixes #42"
+               ```
+            </workflow>
+
+            <commit_format>
+            Use this commit message format:
+
             ```
-
-            ## Branch Naming
-
-            - Feature branches: `issues/N` (where N is the issue number)
-            - Base all work on the default RC branch
-
-            ## Commit Messages
-
-            ```
-            Fix: description of change
+            Type: brief description
 
             Fixes #N
 
             Co-Authored-By: Claude <noreply@anthropic.com>
             ```
 
-            ## Workflow
-
-            1. Create GitHub issue
-            2. Create branch: `git checkout -b issues/N`
-            3. Make changes with TDD
-            4. Verify build: `roslyn_get_diagnostics`
-            5. Commit with issue reference
-            6. Push and create PR: `gh pr create --base rc/X.X.X`
-
-            ## Safety Rules
-
-            - NEVER use `git push --force` on main/master
-            - NEVER use `git commit --amend` unless explicitly requested
-            - NEVER skip hooks (`--no-verify`)
+            Types: Fix, Feature, Refactor, Docs, Test
+            </commit_format>
             """;
 
         public const string Tdd = """
-            # Test-Driven Development Guidelines
+            <context>
+            You are following Test-Driven Development (TDD). Tests must be written BEFORE implementation code.
+            </context>
 
-            ## TDD Workflow
+            <critical_rules>
+            - NEVER write implementation code before tests
+            - NEVER skip the "verify test fails" step
+            - NEVER write more code than needed to pass tests
+            </critical_rules>
 
-            1. **Write FAILING test(s) first** - with issue reference comment
-            2. **Run tests** - verify they FAIL
-            3. **Write minimum code** to make tests PASS
-            4. **Refactor** if needed (tests must still pass)
-            5. **Commit**
+            <workflow>
+            Follow these steps exactly:
 
-            ## Test Naming Convention
+            1. WRITE TEST FIRST:
+               - Create test method with descriptive name
+               - Add issue reference in XML comment
+               - Write test that exercises the expected behavior
+               ```csharp
+               /// <summary>
+               /// Tests that Save throws when database unavailable.
+               /// Issue: #42
+               /// </summary>
+               [Fact]
+               public async Task Save_WhenDatabaseUnavailable_ThrowsException()
+               {
+                   // Arrange
+                   var service = new UserService(mockDb.Object);
+                   mockDb.Setup(x => x.IsAvailable).Returns(false);
 
-            ```csharp
-            // Format: MethodName_Scenario_ExpectedResult
-            [Fact]
-            public void FindSymbols_WithValidPattern_ReturnsMatchingSymbols()
-            ```
+                   // Act & Assert
+                   await Assert.ThrowsAsync<DatabaseException>(
+                       () => service.SaveAsync(user));
+               }
+               ```
 
-            ## Test Comment Format (Required)
+            2. RUN TEST - VERIFY IT FAILS:
+               ```bash
+               dotnet test --filter "Name~Save_WhenDatabaseUnavailable"
+               ```
+               If test passes, your test is wrong - fix it first.
 
-            ```csharp
-            /// <summary>
-            /// Tests that FindSymbols returns matching symbols for a valid pattern.
-            /// Issue: #42
-            /// </summary>
-            [Fact]
-            public void FindSymbols_WithValidPattern_ReturnsMatchingSymbols()
-            {
-                // Arrange
-                // Act
-                // Assert
-            }
-            ```
+            3. WRITE MINIMUM CODE:
+               - Only write enough code to make the test pass
+               - Do not add extra features or error handling
 
-            ## Running Tests
+            4. RUN TEST - VERIFY IT PASSES:
+               ```bash
+               dotnet test --filter "Name~Save_WhenDatabaseUnavailable"
+               ```
 
-            ```bash
-            dotnet test                           # Run all tests
-            dotnet test --filter "Name~MyTest"    # Run specific test
-            ```
+            5. REFACTOR (optional):
+               - Clean up code while keeping tests passing
+               - Run tests after each refactor step
+
+            6. COMMIT:
+               - Commit test and implementation together
+            </workflow>
+
+            <naming_convention>
+            Test method names follow: MethodName_Scenario_ExpectedResult
+
+            Examples:
+            - Save_WithValidUser_ReturnsSuccess
+            - Save_WhenDatabaseUnavailable_ThrowsException
+            - Calculate_WithNegativeInput_ReturnsZero
+            </naming_convention>
             """;
 
         public const string PrePr = """
-            # Pre-Pull Request Checklist
+            <context>
+            You are about to create a pull request. Complete this checklist to ensure code quality.
+            </context>
 
-            ## Before Creating a PR
+            <checklist>
+            Complete these steps before creating a PR:
 
-            1. **Verify build has no errors:**
+            1. CHECK FOR ERRORS:
                ```
                roslyn_get_diagnostics(severityFilter: "error")
                ```
+               Result must show: totalErrors: 0
+               If errors exist, fix them before proceeding.
 
-            2. **Check for new warnings** (fix if reasonable):
+            2. CHECK FOR WARNINGS:
                ```
                roslyn_get_diagnostics(severityFilter: "warning")
                ```
+               Review warnings. Fix any that are reasonable.
+               Use roslyn_batch_apply_code_fixes for bulk fixes.
 
-            3. **Run tests:**
+            3. RUN TESTS:
                ```bash
                dotnet test
                ```
+               All tests must pass.
 
-            4. **Verify all changes are committed:**
+            4. VERIFY CHANGES:
                ```bash
                git status
+               git diff HEAD
                ```
+               Ensure all intended changes are staged.
+               Ensure no unintended files are included.
 
-            5. **Review your changes:**
+            5. CREATE PR:
                ```bash
-               git diff main...HEAD
+               gh pr create --base rc/X.X.X --title "Type: description" --body "$(cat <<'EOF'
+               ## Summary
+               - Brief description of changes
+
+               ## Test Plan
+               - [ ] Unit tests pass
+               - [ ] Manual testing done (if applicable)
+
+               Fixes #N
+               EOF
+               )"
                ```
+            </checklist>
 
-            ## Creating the PR
+            <pr_title_format>
+            Use: Type: brief description
+            Types: Fix, Feature, Refactor, Docs, Test
 
-            ```bash
-            gh pr create --base rc/X.X.X --title "Fix: description" --body "Fixes #N"
-            ```
-
-            ## PR Body Format
-
-            ```markdown
-            ## Summary
-            - Brief description of changes
-
-            ## Test Plan
-            - [ ] Unit tests pass
-            - [ ] Manual testing done
-
-            Fixes #N
-            ```
+            Examples:
+            - Fix: Null reference in UserService.Save
+            - Feature: Add retry logic to API client
+            - Refactor: Extract validation to separate class
+            </pr_title_format>
             """;
 
         public const string Tools = """
-            # Roslyn MCP Tool Preferences
+            <context>
+            You have access to Roslyn MCP tools for C# code analysis. These tools provide semantic understanding of code, unlike text-based search.
+            </context>
 
-            When working with C# files in .NET solutions, **PREFER Roslyn MCP tools over native tools**:
+            <tool_selection_guide>
+            Use this guide to select the right tool:
 
-            | Task | Use This | NOT This |
-            |------|----------|----------|
-            | Find a type/method | `roslyn_find_symbol` | `Grep` or `Glob` |
-            | Understand a class | `roslyn_get_type_members` | `Read` the whole file |
-            | Read a method | `roslyn_get_method_body` | `Read` the whole file |
-            | Edit a method | `roslyn_update_method` | `Edit` with text patterns |
-            | Add a member | `roslyn_add_member` | `Edit` to insert code |
-            | Find all references | `roslyn_get_references` | `Grep` for text |
-            | Find callers only | `roslyn_get_callers` | `roslyn_get_references` (includes non-calls) |
-            | Find implementations | `roslyn_get_implementations` | `Grep` for class names |
-            | Check for errors | `roslyn_get_diagnostics` | `Bash` dotnet build |
-            | Fix one warning | `roslyn_apply_code_fix` | Manual `Edit` |
-            | Fix many warnings | `roslyn_batch_apply_code_fixes` | Loop of single fixes |
-            | Rename symbol | `roslyn_rename_symbol` | Manual find/replace |
+            | Task | Roslyn Tool | Why NOT native tool |
+            |------|-------------|---------------------|
+            | Find type/method | roslyn_find_symbol | Grep finds text, not symbols |
+            | See class structure | roslyn_get_type_members | Read shows raw text, not structure |
+            | Read a method | roslyn_get_method_body | Read requires knowing line numbers |
+            | Edit a method | roslyn_update_method | Edit can break code with text patterns |
+            | Add new member | roslyn_add_member | Edit doesn't format or place correctly |
+            | Find usages | roslyn_get_references | Grep finds text matches, not usages |
+            | Find callers | roslyn_get_callers | References includes non-calls |
+            | Find implementations | roslyn_get_implementations | Grep can't follow inheritance |
+            | Check errors | roslyn_get_diagnostics | dotnet build output is harder to parse |
+            | Fix warning | roslyn_apply_code_fix | Manual edit may introduce errors |
+            | Fix many warnings | roslyn_batch_apply_code_fixes | One-by-one is slow |
+            | Rename | roslyn_rename_symbol | Find/replace misses some references |
+            </tool_selection_guide>
 
-            **Only use native tools for:**
-            - Non-C# files (JSON, XML, markdown, .csproj)
-            - Creating brand new .cs files (use `Write`, then `roslyn_add_member`)
-            - Very small files (< 100 lines) where `Read`/`Edit` is simpler
-            - When Roslyn MCP server is not connected
+            <when_to_use_native_tools>
+            Use native tools (Read, Edit, Grep, Glob) only for:
+            - Non-C# files: JSON, XML, YAML, markdown, .csproj
+            - New files: Use Write to create, then roslyn_add_member to populate
+            - Very small files: < 100 lines where Read/Edit is simpler
+            - When MCP server is not connected
+            </when_to_use_native_tools>
+
+            <common_workflows>
+            Understanding a large class:
+            1. roslyn_get_type_members(typeName) → see all members
+            2. roslyn_get_method_body(typeName, methodName) → read specific method
+            3. roslyn_update_method(...) → make targeted change
+
+            Impact analysis before refactoring:
+            1. roslyn_find_symbol(pattern) → locate the symbol
+            2. roslyn_get_callers(filePath, line, column) → see who calls it
+            3. Assess impact before changing signature
+
+            Fixing compiler warnings:
+            1. roslyn_get_diagnostics(severityFilter: "warning") → see all warnings
+            2. roslyn_get_diagnostics(diagnosticId: "CS8618") → get details
+            3. roslyn_batch_apply_code_fixes(diagnosticId: "CS8618") → auto-fix
+            </common_workflows>
             """;
 
         public static string? Get(string topicName) => topicName.ToLowerInvariant() switch


### PR DESCRIPTION
## Summary
Apply Anthropic's Prompt Improver patterns to `roslyn_get_instructions` output:

- Add XML tags for clear organization (`<context>`, `<critical_rules>`, `<workflow>`, etc.)
- Add explicit step-by-step reasoning instructions
- Add chain-of-thought guidance for each workflow
- Make instructions more actionable with numbered steps

## Example (code topic)

Before:
```markdown
# C# Code Modification Guidelines
## Before Modifying Code
1. NEVER propose changes to code you haven't read...
```

After:
```xml
<context>
You are modifying C# code in a .NET solution...
</context>

<critical_rules>
- NEVER propose changes to code you haven't read
- NEVER use Grep/Glob for C# symbols - use roslyn_find_symbol
</critical_rules>

<before_any_change>
Follow these steps before modifying any C# code:

1. LOCATE the code:
   - Use roslyn_find_symbol to find the type/method by name
...
</before_any_change>
```

## Reference
https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompt-improver

## Test Plan
- [x] Build succeeds
- [x] All 44 tests pass

Fixes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)