### PR TITLE
Docs: Improve README and templates for new users

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,1097 +2,121 @@
 
 ## Project Overview
 
-This is a **Model Context Protocol (MCP) server** written in C# (.NET 10.0) that provides C# solution analysis capabilities using Microsoft's Roslyn compiler platform (Microsoft.CodeAnalysis).
+This is a **Model Context Protocol (MCP) server** written in C# (.NET 10.0) that provides C# solution analysis capabilities using Microsoft's Roslyn compiler platform.
 
-The server enables AI assistants to analyze .NET solutions with deep semantic understanding - finding symbols, tracking references, understanding build order, and more.
+The server enables AI assistants to analyze .NET solutions with deep semantic understanding - finding symbols, tracking references, understanding call graphs, and more.
 
-## IMPORTANT: Maintain CLAUDE_TEMPLATE.md
+## Development Guidelines
 
-**When adding new tools or features, YOU MUST update `CLAUDE_TEMPLATE.md`.**
+For C# code modifications: `roslyn_get_instructions(topic: "code")`
+For git workflow: `roslyn_get_instructions(topic: "git")`
+For TDD workflow: `roslyn_get_instructions(topic: "tdd")`
+Before creating PR: `roslyn_get_instructions(topic: "pre-pr")`
+For all available tools: `roslyn_get_instructions(topic: "tools")`
 
-This file is a template for end users to copy to their projects. Keep it:
-- **Current** - Include all available tools in the tool preferences table
-- **Generic** - No references to this repository's internals (git workflow, roadmap, etc.)
-- **Practical** - Focus on how to USE the tools, not how they're implemented
+## Project-Specific Rules
 
-**Checklist when adding a new tool:**
-1. Add to the tool preferences table in CLAUDE_TEMPLATE.md (if user-facing)
-2. Add to "Common Workflows" section if it enables a new workflow
-3. Keep examples generic (not specific to RoslynMcpServer development)
+### IMPORTANT: Maintain Instruction Files
 
-## Tool Preferences for C# Code
+When adding new tools, **YOU MUST update `Instructions/Topics/tools.md`**.
 
-When working with C# files in .NET solutions, **PREFER Roslyn MCP tools over native tools**:
+Also update `CLAUDE_TEMPLATE.md` if the tool is user-facing.
 
-| Task | Use This | NOT This |
-|------|----------|----------|
-| Find a type/method | `roslyn_find_symbol` | `Grep` or `Glob` |
-| Understand a class | `roslyn_get_type_members` | `Read` the whole file |
-| Read a method | `roslyn_get_method_body` | `Read` the whole file |
-| Edit a method | `roslyn_update_method` | `Edit` with text patterns |
-| Add a member | `roslyn_add_member` | `Edit` to insert code |
-| Find all references | `roslyn_get_references` | `Grep` for text |
-| Find callers only | `roslyn_get_callers` | `roslyn_get_references` (includes non-calls) |
-| Find implementations | `roslyn_get_implementations` | `Grep` for class names |
-| Check for errors | `roslyn_get_diagnostics` | `Bash` dotnet build |
-| Fix one warning | `roslyn_apply_code_fix` | Manual `Edit` |
-| Fix many warnings | `roslyn_batch_apply_code_fixes` | Loop of single fixes |
-| Rename symbol | `roslyn_rename_symbol` | Manual find/replace |
-| Write XML docs | `roslyn_get_type_members` + `roslyn_get_method_body` | `Read` file |
+### Code Guidelines
 
-**Only use native tools for:**
-- Non-C# files (JSON, XML, markdown, .csproj)
-- Creating brand new .cs files (use `Write`, then `roslyn_add_member` to populate)
-- Very small files (< 100 lines) where `Read`/`Edit` is simpler
-- When Roslyn MCP server is not connected
-
-**Example: Writing XML docs for a class**
-```
-1. roslyn_get_type_members(typeName: "MyClass") → see all members, their signatures, accessibility
-2. roslyn_get_method_body(typeName: "MyClass", methodName: "DoWork") → read implementation
-3. Write meaningful XML doc based on understanding
-4. roslyn_update_method() or Edit to add the docs
-```
-
-## MANDATORY: Test Driven Development (TDD)
-
-**YOU MUST follow TDD for ALL code changes. No exceptions.**
-
-### Rules
-
-1. **NO CODE WITHOUT ISSUE** - Every code change MUST have an associated GitHub issue
-2. **NO CODE WITHOUT TESTS** - Every feature/fix MUST have unit tests
-3. **TESTS FIRST** - Write failing tests BEFORE writing implementation code
-4. **TEST COMMENTS** - Every test method MUST have a comment referencing the GitHub issue
-
-### TDD Workflow
-
-```
-1. Create GitHub issue describing the feature/bug
-2. Create issues/N branch
-3. Write FAILING test(s) first - with issue reference comment
-4. Run tests - verify they FAIL
-5. Write minimum code to make tests PASS
-6. Refactor if needed (tests must still pass)
-7. Commit, PR, merge
-```
-
-### Test Project Structure
-
-```
-RoslynMcpServer.Tests/
-├── RoslynMcpServer.Tests.csproj    # xUnit test project
-├── Services/                        # Tests for service classes
-│   ├── SolutionAnalyzerServiceTests.cs
-│   └── ...
-├── Tools/                           # Tests for MCP tools
-│   └── ...
-└── Models/                          # Tests for DTOs/models
-    └── ...
-```
-
-### Test Naming Convention
-
-```csharp
-// Format: MethodName_Scenario_ExpectedResult
-[Fact]
-public void FindSymbols_WithValidPattern_ReturnsMatchingSymbols()
-
-[Fact]
-public async Task GetDiagnosticsAsync_WhenSolutionNotFound_ReturnsError()
-```
-
-### Test Comment Format (REQUIRED)
-
-```csharp
-/// <summary>
-/// Tests that FindSymbols returns matching symbols for a valid pattern.
-/// Issue: #42
-/// </summary>
-[Fact]
-public void FindSymbols_WithValidPattern_ReturnsMatchingSymbols()
-{
-    // Arrange
-    // Act
-    // Assert
-}
-```
-
-### Running Tests
-
-```bash
-# Run all tests
-dotnet test
-
-# Run with coverage
-dotnet test --collect:"XPlat Code Coverage"
-
-# Run specific test class
-dotnet test --filter "FullyQualifiedName~SolutionAnalyzerServiceTests"
-```
-
-## Code Guidelines
-
-- **YOU MUST keep .cs files under 300 lines.** Before splitting, THINK about proper refactoring:
-  1. Extract helper classes or utilities (prefer composition)
-  2. Apply SOLID principles (Single Responsibility, etc.)
-  3. Use partial classes only as a last resort when logic truly belongs together
+- Keep .cs files under 300 lines (extract helper classes if needed)
 - Use C# 12 features (primary constructors, collection expressions)
-- Prefer `required` properties over constructor parameters for DTOs
 - Use `async/await` for all I/O operations
-- Error messages should be actionable (tell the user what to do)
 - All logging goes to stderr (`Console.Error.WriteLine`)
 
-## Current Status
+### Test Requirements
 
-**Phase 2 Complete**: Roslyn analysis capabilities added.
-
-- MCP protocol implementation (JSON-RPC 2.0 over stdio)
-- Tool registration system
-- Roslyn integration with MSBuildWorkspace
-- Solution loading and project dependency analysis
-- Symbol search with semantic filtering
-- Find all references to symbols
+- Every code change MUST have an associated GitHub issue
+- Every feature/fix MUST have unit tests with issue reference comment
+- Follow TDD: write failing tests BEFORE implementation
 
 ## Tech Stack
 
 - **.NET 10.0** - Target framework
-- **System.Text.Json** - JSON serialization for MCP protocol
-- **Microsoft.CodeAnalysis.Workspaces.MSBuild** - Roslyn code analysis
-- **Microsoft.CodeAnalysis.CSharp.Workspaces** - C# language support
-- **Microsoft.Build.Locator** - Finds MSBuild installations
-- **xUnit** - Unit testing framework
+- **Microsoft.CodeAnalysis** - Roslyn code analysis
+- **Microsoft.Build.Locator** - MSBuild discovery
+- **xUnit** - Unit testing
+- **SQLite** (via RoslynMcpServer.Graph) - Call graph caching
 
 ## Project Structure
 
 ```
 RoslynMcpServer/
-├── CLAUDE.md                     # This file
-├── .mcp.json                     # MCP server configuration for Claude Code
-├── RoslynMcpServer.csproj        # Project file
-├── RoslynMcpServer.slnx          # Solution file
-├── Program.cs                    # Entry point
+├── CLAUDE.md                 # This file
+├── Instructions/             # External instruction files (copied to output)
+│   ├── Templates/            # CLAUDE.md templates for users
+│   └── Topics/               # Topic-specific instructions
 ├── src/
-│   ├── AnalyzerLoader.cs                         # .NET analyzers loader for CA* rules
-│   ├── McpServer.cs                              # MCP protocol implementation
-│   ├── Models.cs                                 # DTOs and result types
-│   ├── Models.Symbols.cs                         # Symbol/reference DTOs
-│   ├── Models.Methods.cs                         # Method body/update DTOs
-│   ├── Models.Diagnostics.cs                     # Diagnostic DTOs
-│   ├── Models.CodeFix.cs                         # Code fix/rename DTOs
-│   ├── RoslynTools.cs                            # Core tool registration
-│   ├── RoslynTools.FindSymbol.cs                 # Symbol search tool
-│   ├── RoslynTools.References.cs                 # References tool
-│   ├── RoslynTools.Implementations.cs            # Implementations tool
-│   ├── RoslynTools.TypeMembers.cs                # Type members tool
-│   ├── RoslynTools.MethodBody.cs                 # Get method body tool
-│   ├── RoslynTools.UpdateMethod.cs               # Update method tool
-│   ├── RoslynTools.Diagnostics.cs                # Diagnostics tool
-│   ├── RoslynTools.AddMember.cs                  # Add member tool
-│   ├── RoslynTools.CodeFix.cs                    # Single code fix tool
-│   ├── RoslynTools.BatchCodeFix.cs               # Batch code fix tool
-│   ├── RoslynTools.Rename.cs                     # Rename symbol tool
-│   ├── SolutionAnalyzerService.cs                # Core service + projects
-│   ├── SolutionAnalyzerService.Symbols.cs        # Symbol search logic
-│   ├── SolutionAnalyzerService.References.cs     # References logic
-│   ├── SolutionAnalyzerService.Implementations.cs # Implementations logic
-│   ├── SolutionAnalyzerService.TypeMembers.cs    # Type members logic
-│   ├── SolutionAnalyzerService.MethodBody.cs     # Get method body logic
-│   ├── SolutionAnalyzerService.UpdateMethod.cs   # Update method logic
-│   ├── SolutionAnalyzerService.Diagnostics.cs    # Diagnostics logic
-│   ├── SolutionAnalyzerService.AddMember.cs      # Add member logic
-│   ├── SolutionAnalyzerService.CodeFix.cs        # Single code fix logic
-│   ├── SolutionAnalyzerService.BatchCodeFix.cs   # Batch code fix logic
-│   ├── SolutionAnalyzerService.Rename.cs         # Rename symbol logic
-│   └── SolutionAnalyzerService.WpfSupport.cs     # WPF/XAML generated file inclusion
-└── RoslynMcpServer.Tests/                        # xUnit test project
-    ├── RoslynMcpServer.Tests.csproj
-    ├── Services/                                 # Service tests
-    ├── Tools/                                    # Tool tests
-    └── Models/                                   # Model tests
+│   ├── McpServer.cs          # MCP protocol implementation
+│   ├── RoslynTools*.cs       # Tool registrations (partial classes)
+│   ├── SolutionAnalyzerService*.cs  # Roslyn analysis (partial classes)
+│   ├── Instructions.cs       # Reads instruction files
+│   └── Models*.cs            # DTOs
+├── RoslynMcpServer.Graph/    # Call graph database project
+└── RoslynMcpServer.Tests/    # xUnit tests
 ```
 
-## Build Commands
+## Build & Test
 
 ```bash
-# Build
-dotnet build
-
-# Run directly
-dotnet run
-
-# Test with JSON-RPC message
-echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}' | dotnet run
+dotnet build           # Build
+dotnet test            # Run tests
+dotnet run             # Run MCP server
 ```
 
-## Development Workflow
+### Rebuilding After Code Changes
 
-### Rebuilding after code changes
+The MCP server runs as a background process:
 
-The MCP server runs as a background process. To apply code changes:
-
-1. **Find and kill the running process:**
-   ```bash
-   # Find the process
-   tasklist | findstr -i RoslynMcpServer
-
-   # Kill by PID (replace 12345 with actual PID)
-   taskkill /F /PID 12345
-   ```
-
-2. **Rebuild:**
-   ```bash
-   dotnet build
-   ```
-
-3. **Reconnect in Claude Code:**
-   - Type `/mcp` to open MCP menu
-   - Select the roslyn server and reconnect
-   - Or use: `/mcp reconnect roslyn`
+1. Kill running process: `taskkill //F //PID <pid>`
+2. Rebuild: `dotnet build`
+3. Reconnect in Claude Code: `/mcp` → reconnect roslyn
 
 ## Git Workflow
 
-### Branch Structure
-
-```
-rc/X.X.X          ← Default branch (release candidate), PRs target here
-├── issues/N      ← Feature/fix branches linked to GitHub issues
-└── issues/M
-
-release/X.X.X     ← Stable releases (owner merges RC here when ready)
-master            ← Historical, not used for development
-```
-
-### Development Workflow (for Claude)
-
-**IMPORTANT: Always create a GitHub issue BEFORE making code changes.**
-
-1. **Create GitHub Issue First**
-   ```bash
-   gh issue create --title "Brief description" --body "Detailed description" --label "bug"
-   ```
-   Note the issue number (e.g., `#42`)
-
-   **Required labels** (use `--label`):
-   - `bug` - Something isn't working
-   - `enhancement` - New feature or request
-   - `documentation` - Docs improvements
-   - `refactor` - Code restructuring (create this label if missing)
-
-2. **Create Feature Branch**
-   ```bash
-   git checkout rc/X.X.X
-   git pull
-   git checkout -b issues/42
-   ```
-
-3. **Make Changes and Commit**
-   ```bash
-   git add .
-   git commit -m "Fix: description of change
-
-   Closes #42
-
-   Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>"
-   ```
-
-4. **Push and Create PR**
-   ```bash
-   git push -u origin issues/42
-   gh pr create --base rc/X.X.X --title "Fix: description" --body "Closes #42"
-   ```
-
-5. **Merge PR** (after review if needed)
-   ```bash
-   gh pr merge --squash --delete-branch
-   ```
-
-6. **Switch Back to RC**
-   ```bash
-   git checkout rc/X.X.X
-   git pull
-   ```
-
-### Working with Existing GitHub Issues
-
-When fixing bugs or implementing features from **existing** GitHub issues:
-
-1. **DO NOT create new issues** - work on the existing issue
-2. **Add comments** to the issue explaining:
-   - Root cause analysis
-   - The fix applied
-   - File and line numbers changed
-3. **Reference the issue** in commit messages: `Fixes #1234`
-4. Use `gh issue comment <number> --body "..."` to add comments
-
-**Reading issue attachments (images):**
-- GitHub user-attachments require signed URLs
-- Ask user for the signed URL (right-click image → Copy image address)
-- Download with: `curl -s -L -o image.png "<signed-url>"`
-- Then use Read tool to view the image
-
-### Version Management
-
-**Version is defined in ONE place:** `RoslynMcpServer.csproj`
-
-```xml
-<Version>1.0.0-rc</Version>
-```
-
-Both `McpServer.cs` and `RoslynTools.cs` read this at runtime via assembly attributes.
-
-**Version Format:**
-- Release Candidate: `X.X.X-rc` (e.g., `1.0.0-rc`)
-- Release: `X.X.X` (e.g., `1.0.0`)
-
-**The version in MCP server responses MUST match the branch:**
-- On `rc/1.0.0` branch → version should be `1.0.0-rc`
-- On `release/1.0.0` branch → version should be `1.0.0`
-
-### Release Process (Owner Only)
-
-1. Review cumulative changes in RC branch
-2. Merge `rc/X.X.X` → `release/X.X.X`
-3. Update version in `.csproj` to remove `-rc` suffix
-4. Tag the release
-5. Bump RC version for next cycle (e.g., `1.0.1-rc`)
-
-### GitHub CLI Commands Reference
-
-```bash
-# Check current default branch
-gh repo view --json defaultBranchRef
-
-# Create issue
-gh issue create --title "Title" --body "Description"
-
-# Create PR
-gh pr create --base rc/X.X.X --title "Title" --body "Closes #N"
-
-# Merge PR
-gh pr merge --squash --delete-branch
-
-# View PR status
-gh pr status
-```
-
-## Available Tools
-
-| Tool | Description |
-|------|-------------|
-| `roslyn_echo` | Echo test - returns the message you send |
-| `roslyn_get_server_info` | Returns server version and capabilities |
-| `roslyn_get_projects_in_build_order` | Loads a solution and returns projects in build order (dependencies first) |
-| `roslyn_find_symbol` | Semantic search for types, methods, properties by name pattern |
-| `roslyn_get_references` | Find all references to a symbol at a given position |
-| `roslyn_get_callers` | Find all callers of a method (only call sites, not declarations) |
-| `roslyn_get_implementations` | Find all implementations of an interface or derived classes |
-| `roslyn_get_type_members` | Get all members (methods, properties, fields, events) of a type |
-| `roslyn_get_method_body` | Get full source code of a specific method |
-| `roslyn_update_method` | Replace a method's implementation with new source code |
-| `roslyn_get_diagnostics` | Compile solution and get warnings/errors with counts and details |
-| `roslyn_add_member` | Add a new method/property/field to a type with auto-formatting |
-| `roslyn_apply_code_fix` | Apply Roslyn's suggested fix for a single diagnostic |
-| `roslyn_batch_apply_code_fixes` | Batch apply fixes for all diagnostics of a specific type |
-| `roslyn_rename_symbol` | Rename a symbol across the entire solution with all references |
-| `roslyn_get_template` | Get a CLAUDE.md template for C# projects |
-| `roslyn_get_instructions` | Get development instructions for a specific topic |
-
-### roslyn_find_symbol
-
-Searches for symbols in a solution by name pattern. Much faster and more accurate than text search.
-
-**Input:**
-```json
-{
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "pattern": "Layer",
-  "symbolKind": "type",
-  "matchType": "contains",
-  "maxResults": 100
-}
-```
-
-**Parameters:**
-- `solutionPath` (required) - Absolute path to .sln file
-- `pattern` (required) - Symbol name to search for
-- `symbolKind` - `all`, `type`, `member`, `namespace`, `typeAndMember` (default: `all`)
-- `matchType` - `exact`, `exactIgnoreCase`, `contains`, `prefix`, `suffix` (default: `contains`)
-- `maxResults` - Limit results 1-1000 (default: 100)
-
-**Output:**
-```json
-{
-  "success": true,
-  "pattern": "Layer",
-  "totalFound": 15,
-  "symbols": [
-    {
-      "name": "LayerCollection",
-      "fullyQualifiedName": "Atlas.Data.LayerCollection",
-      "kind": "Class",
-      "filePath": "C:\\path\\to\\LayerCollection.cs",
-      "line": 12,
-      "accessibility": "Public",
-      "signature": "class LayerCollection"
-    }
-  ]
-}
-```
-
-### roslyn_get_references
-
-Finds all references to a symbol at a given file position. Essential for impact analysis and refactoring. Supports pagination and filtering.
-
-**Input:**
-```json
-{
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "filePath": "C:\\path\\to\\MyClass.cs",
-  "line": 15,
-  "column": 22,
-  "maxResults": 100,
-  "projectFilter": "Atlas.*",
-  "fileFilter": "*Controller.cs"
-}
-```
-
-**Parameters:**
-- `solutionPath` (required) - Absolute path to .sln file
-- `filePath` (required) - Absolute path to the source file containing the symbol
-- `line` (required) - Line number (1-based) where the symbol is located
-- `column` (required) - Column number (1-based) where the symbol is located
-- `maxResults` - Maximum references to return (default: 100, max: 10000)
-- `projectFilter` - Filter by project name, supports wildcards (`*`). Example: `Atlas.*`
-- `fileFilter` - Filter by file path, supports wildcards (`*`). Example: `*Service.cs`
-
-**Output:**
-```json
-{
-  "success": true,
-  "symbol": {
-    "name": "MyMethod",
-    "fullyQualifiedName": "MyNamespace.MyClass.MyMethod()",
-    "kind": "Method",
-    "signature": "void MyMethod()"
-  },
-  "totalFound": 387,
-  "returnedCount": 100,
-  "references": [
-    {
-      "filePath": "C:\\path\\to\\Caller.cs",
-      "line": 42,
-      "column": 12,
-      "projectName": "MyProject",
-      "preview": "instance.MyMethod();"
-    }
-  ]
-}
-```
-
-### roslyn_get_callers
-
-Finds all callers of a method at a given position. Unlike `roslyn_get_references`, this returns only actual call sites - not declarations, docs, mocks, or type references. Essential for understanding execution flow and impact analysis before refactoring.
-
-**Input:**
-```json
-{
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "filePath": "C:\\path\\to\\UserRepository.cs",
-  "line": 25,
-  "column": 17,
-  "maxResults": 100,
-  "offset": 0,
-  "projectFilter": "MyApp.*",
-  "fileFilter": "*Service.cs"
-}
-```
-
-**Parameters:**
-- `solutionPath` (required) - Absolute path to .sln file
-- `filePath` (required) - Absolute path to the source file containing the method
-- `line` (required) - Line number (1-based) where the method is located
-- `column` (required) - Column number (1-based) where the method is located
-- `maxResults` - Maximum callers to return (default: 100, max: 1000)
-- `offset` - Skip first N results for pagination (default: 0)
-- `projectFilter` - Filter by project name, supports wildcards (`*`)
-- `fileFilter` - Filter by file path, supports wildcards (`*`)
-
-**Output (compact):**
-```json
-{
-  "success": true,
-  "symbol": "UserRepository.Save(User)",
-  "totalCallers": 47,
-  "returnedCount": 47,
-  "callers": [
-    { "file": "Services\\UserService.cs", "line": 67, "method": "CreateUser", "type": "UserService" },
-    { "file": "Jobs\\ImportJob.cs", "line": 112, "method": "ProcessBatch", "type": "ImportJob" }
-  ]
-}
-```
-
-**When to use `roslyn_get_callers` vs `roslyn_get_references`:**
-- **`roslyn_get_callers`**: When you need to know who CALLS a method (execution flow, impact analysis)
-- **`roslyn_get_references`**: When you need ALL mentions (including declarations, docs, interface definitions)
-
-### roslyn_get_implementations
-
-Finds all implementations of an interface or all classes derived from a base class. Essential for understanding inheritance hierarchies and finding all variants of a pattern.
-
-**Input:**
-```json
-{
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "typeName": "IOperation",
-  "includeBaseType": false,
-  "maxResults": 100
-}
-```
-
-**Parameters:**
-- `solutionPath` (required) - Absolute path to .sln file
-- `typeName` (required) - Name of the interface or base class
-- `includeBaseType` - Include the base type itself in results (default: false)
-- `maxResults` - Maximum implementations to return (default: 100)
-
-**Output:**
-```json
-{
-  "success": true,
-  "baseType": {
-    "name": "IOperation",
-    "fullyQualifiedName": "Atlas.Operations.IOperation",
-    "kind": "Interface"
-  },
-  "totalFound": 15,
-  "implementations": [
-    {
-      "name": "OperateSplit",
-      "fullyQualifiedName": "Atlas.Operations.OperateSplit",
-      "kind": "Class",
-      "filePath": "C:\\path\\to\\OperateSplit.cs",
-      "line": 12,
-      "isAbstract": false,
-      "baseTypes": ["BaseOperation"],
-      "interfaces": ["Atlas.Operations.IOperation"]
-    }
-  ]
-}
-```
-
-### roslyn_get_projects_in_build_order
-
-Loads a .NET solution file and returns all projects in topological build order (dependencies first).
-
-**Input:**
-```json
-{
-  "solutionPath": "C:\\path\\to\\solution.sln"
-}
-```
-
-**Output:**
-```json
-{
-  "success": true,
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "projects": [
-    {
-      "name": "MyLibrary",
-      "filePath": "C:\\path\\to\\MyLibrary.csproj",
-      "language": "C#",
-      "dependencies": []
-    },
-    {
-      "name": "MyApp",
-      "filePath": "C:\\path\\to\\MyApp.csproj",
-      "language": "C#",
-      "dependencies": ["MyLibrary"]
-    }
-  ]
-}
-```
-
-### roslyn_get_type_members
-
-Gets all members of a type including methods, properties, fields, events, and constructors. Essential for understanding the structure of large classes without reading the entire file.
-
-**Input:**
-```json
-{
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "typeName": "FeatureLayer",
-  "memberKind": "methods",
-  "includeInherited": false,
-  "compact": true
-}
-```
-
-**Parameters:**
-- `solutionPath` (required) - Absolute path to .sln file
-- `typeName` (required) - Name of the type (class, interface, struct)
-- `memberKind` - `all`, `methods`, `properties`, `fields`, `events`, `constructors` (default: `all`)
-- `includeInherited` - Include members from base classes (default: false)
-- `compact` - Return minimal fields only (default: true)
-
-**Output:**
-```json
-{
-  "success": true,
-  "type": { "name": "FeatureLayer", "kind": "Class" },
-  "totalMembers": 45,
-  "members": [
-    { "name": "BuildCachedData", "kind": "Method", "signature": "void BuildCachedData(CancellationToken, bool)" },
-    { "name": "Invalidate", "kind": "Method", "signature": "void Invalidate()" }
-  ]
-}
-```
-
-### roslyn_get_method_body
-
-Gets the full source code of a method including its implementation. Returns the complete method text that can be edited and applied back. Essential for working with large classes without reading the entire file.
-
-**Input:**
-```json
-{
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "typeName": "FeatureLayer",
-  "methodName": "BuildCachedData",
-  "parameterTypes": "CancellationToken, bool"
-}
-```
-
-**Parameters:**
-- `solutionPath` (required) - Absolute path to .sln file
-- `typeName` (required) - Name of the type containing the method
-- `methodName` (required) - Name of the method (use `.ctor` for constructors)
-- `parameterTypes` - Parameter types to identify overload (e.g., `string, int`)
-
-**Output:**
-```json
-{
-  "success": true,
-  "typeName": "FeatureLayer",
-  "methodName": "BuildCachedData",
-  "filePath": "C:\\path\\to\\FeatureLayer.cs",
-  "startLine": 780,
-  "endLine": 920,
-  "signature": "private void BuildCachedData(CancellationToken cancellation, bool reuseExistingData)",
-  "sourceCode": "private void BuildCachedData(...) { ... }"
-}
-```
-
-### roslyn_update_method
-
-Replaces a method's implementation with new source code. Uses Roslyn to precisely locate and replace the method while preserving surrounding code. Essential for making targeted changes to large classes.
-
-**Input:**
-```json
-{
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "typeName": "FeatureLayer",
-  "methodName": "BuildCachedData",
-  "parameterTypes": "CancellationToken, bool",
-  "newSourceCode": "private void BuildCachedData(...) { /* new implementation */ }"
-}
-```
-
-**Parameters:**
-- `solutionPath` (required) - Absolute path to .sln file
-- `typeName` (required) - Name of the type containing the method
-- `methodName` (required) - Name of the method to update
-- `newSourceCode` (required) - Complete new method source code
-- `parameterTypes` - Parameter types to identify overload
-
-### roslyn_get_diagnostics
-
-Compiles a .NET solution and returns diagnostics (errors, warnings). Without `diagnosticId`, returns summary (counts by diagnostic code). With `diagnosticId`, returns detailed entries with file/line/method info for targeted fixing.
-
-**Input (summary mode):**
-```json
-{
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "severityFilter": "warning",
-  "projectFilter": "Atlas.Controls"
-}
-```
-
-**Input (detail mode):**
-```json
-{
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "diagnosticId": "CS8618",
-  "maxResults": 10,
-  "offset": 0
-}
-```
-
-**Parameters:**
-- `solutionPath` (required) - Absolute path to .sln file
-- `diagnosticId` - Specific diagnostic ID to get details for (e.g., `CA2000`, `CS0618`)
-- `severityFilter` - `error`, `warning`, `info`, or `all` (default: `all`)
-- `projectFilter` - Filter by project name (partial match)
-- `maxResults` - Max entries in detail mode (default: 100)
-- `offset` - Pagination offset (default: 0)
-
-**Output (summary):**
-```json
-{
-  "success": true,
-  "totalErrors": 0,
-  "totalWarnings": 1707,
-  "summary": [
-    { "id": "CS8618", "severity": "Warning", "title": "Non-nullable field...", "count": 601 },
-    { "id": "CS8602", "severity": "Warning", "title": "Dereference of possibly null...", "count": 193 }
-  ]
-}
-```
-
-**Output (detail):**
-```json
-{
-  "success": true,
-  "entries": [
-    {
-      "id": "CS8618",
-      "message": "Non-nullable field '_cts' must contain...",
-      "filePath": "C:\\path\\to\\File.cs",
-      "line": 21,
-      "column": 16,
-      "containingType": "MyClass",
-      "containingMethod": "MyMethod"
-    }
-  ],
-  "totalMatchingEntries": 601
-}
-```
-
-### roslyn_add_member
-
-Adds a new member (method, property, field, constructor, event) to a type. Uses Roslyn Formatter for proper indentation. Smart insertion places members with their peers.
-
-**Input:**
-```json
-{
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "typeName": "CacheManager",
-  "memberCode": "public void Dispose() { _cache.Clear(); }",
-  "insertionPoint": "end"
-}
-```
-
-**Parameters:**
-- `solutionPath` (required) - Absolute path to .sln file
-- `typeName` (required) - Name of the type to add the member to
-- `memberCode` (required) - Complete source code of the member to add
-- `insertionPoint` - Where to insert: `start`, `end`, `after-fields`, `after-constructors`, `after-properties`, `before-methods`. Default: smart placement based on member type
-
-**Output:**
-```json
-{
-  "success": true,
-  "filePath": "C:\\path\\to\\CacheManager.cs",
-  "typeName": "MyNamespace.CacheManager",
-  "memberName": "Dispose",
-  "memberKind": "Method",
-  "insertedAtLine": 45,
-  "signature": "void Dispose()"
-}
-```
-
-### roslyn_apply_code_fix
-
-Applies a Roslyn code fix for a diagnostic at a specific location. First use `roslyn_get_diagnostics` to find issues, then use this tool to automatically fix them.
-
-**Input:**
-```json
-{
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "filePath": "C:\\path\\to\\MyClass.cs",
-  "line": 42,
-  "column": 13,
-  "diagnosticId": "CS0168",
-  "fixIndex": 0,
-  "preview": true
-}
-```
-
-**Parameters:**
-- `solutionPath` (required) - Absolute path to .sln file
-- `filePath` (required) - Absolute path to the source file
-- `line` (required) - Line number (1-based)
-- `column` (required) - Column number (1-based)
-- `diagnosticId` - Specific diagnostic ID to fix (e.g., `CS0168`)
-- `fixIndex` - Index of fix to apply when multiple are available
-- `preview` - If true, shows what would change without applying (default: false)
-
-**Output:**
-```json
-{
-  "success": true,
-  "filePath": "C:\\path\\to\\MyClass.cs",
-  "diagnosticId": "CS0168",
-  "diagnosticMessage": "The variable 'ex' is declared but never used",
-  "appliedFixTitle": "Remove unused variable",
-  "availableFixes": [
-    { "index": 0, "title": "Remove unused variable" }
-  ],
-  "filesChanged": 1,
-  "isPreview": false
-}
-```
-
-**Workflow for single fix:**
-1. `roslyn_get_diagnostics` → find CS0168 at line 42
-2. `roslyn_apply_code_fix(preview=true)` → see what would change
-3. `roslyn_apply_code_fix(preview=false)` → apply the fix
-
-### roslyn_batch_apply_code_fixes
-
-Batch applies Roslyn code fixes for all diagnostics of a specific type. Much faster than applying fixes one by one - loads solution once, applies all fixes in memory, then writes changes to disk.
-
-**Input:**
-```json
-{
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "diagnosticId": "CS0168",
-  "projectFilter": "Atlas.Controls",
-  "fileFilter": "*Service.cs",
-  "maxFixes": 100,
-  "preview": false
-}
-```
-
-**Parameters:**
-- `solutionPath` (required) - Absolute path to .sln file
-- `diagnosticId` (required) - Diagnostic ID to fix (e.g., `CS0168`, `CS8618`)
-- `projectFilter` - Filter by project name (partial match)
-- `fileFilter` - Filter by file name or path (partial match)
-- `maxFixes` - Maximum fixes to apply (default: 100, max: 1000)
-- `preview` - If true, shows what would change without applying (default: false)
-
-**Output:**
-```json
-{
-  "success": true,
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "diagnosticId": "CS0168",
-  "totalDiagnosticsFound": 30,
-  "diagnosticsWithFixes": 28,
-  "fixesApplied": 28,
-  "fixesFailed": 2,
-  "filesModified": 15,
-  "modifiedFiles": ["File1.cs", "File2.cs", "..."],
-  "details": [
-    {
-      "filePath": "C:\\path\\to\\MyClass.cs",
-      "line": 42,
-      "column": 13,
-      "diagnosticMessage": "The variable 'ex' is declared but never used",
-      "fixTitle": "Remove unused variable",
-      "applied": true
-    }
-  ],
-  "isPreview": false
-}
-```
-
-**Workflow for batch fixes:**
-1. `roslyn_get_diagnostics` → see summary with `fixAvailable: true` flags
-2. `roslyn_batch_apply_code_fixes(preview=true)` → see what would change
-3. `roslyn_batch_apply_code_fixes(preview=false)` → apply all fixes
-4. `roslyn_get_diagnostics` → verify remaining issues
-
-**When to use batch vs single:**
-- **Batch (`roslyn_batch_apply_code_fixes`)**: Fixing all occurrences of a specific warning type (e.g., all CS0168)
-- **Single (`roslyn_apply_code_fix`)**: Fixing one specific diagnostic, or when you need to choose between multiple fix options
-
-### roslyn_rename_symbol
-
-Renames a symbol (type, method, property, field, parameter, variable) at a specific file position across the entire solution. Updates all references automatically. Essential for safe refactoring without breaking code.
-
-**Input:**
-```json
-{
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "filePath": "C:\\path\\to\\MyClass.cs",
-  "line": 15,
-  "column": 22,
-  "newName": "FetchDataAsync"
-}
-```
-
-**Parameters:**
-- `solutionPath` (required) - Absolute path to .sln file
-- `filePath` (required) - Absolute path to the source file containing the symbol
-- `line` (required) - Line number (1-based) where the symbol is located
-- `column` (required) - Column number (1-based) where the symbol is located
-- `newName` (required) - The new name for the symbol
-
-**Output:**
-```json
-{
-  "success": true,
-  "originalName": "GetData",
-  "newName": "FetchDataAsync",
-  "symbolKind": "Method",
-  "containingType": "MyNamespace.DataService",
-  "totalFilesAffected": 12,
-  "totalChanges": 47,
-  "affectedFiles": [
-    "C:\\path\\to\\DataService.cs",
-    "C:\\path\\to\\DataController.cs",
-    "C:\\path\\to\\Tests\\DataServiceTests.cs"
-  ]
-}
-```
-
-**Workflow:**
-1. Use `roslyn_find_symbol` to locate the symbol you want to rename
-2. Call `roslyn_rename_symbol` with the file path, line, column, and new name
-3. The tool applies the rename immediately and returns affected files
-
-### roslyn_get_template
-
-Returns a CLAUDE.md template for C# projects. Users can copy this to their project root.
-
-**Input:**
-```json
-{
-  "template": "standard"
-}
-```
-
-**Parameters:**
-- `template` (required) - Template type:
-  - `minimal` - Basic MCP pointers only
-  - `standard` - Code + git workflow instructions
-  - `tdd` - Test-driven development workflow
-  - `team` - Full team workflow with issue-first development
-
-**Output:**
-```json
-{
-  "template": "standard",
-  "availableTemplates": ["minimal", "standard", "tdd", "team"],
-  "content": "# CLAUDE.md - C# Development...",
-  "usage": "Copy the content above to a CLAUDE.md file in your project root."
-}
-```
-
-### roslyn_get_instructions
-
-Returns specific development instructions on-demand. Called when a project's CLAUDE.md directs to get instructions for a topic.
-
-**Input:**
-```json
-{
-  "topic": "code"
-}
-```
-
-**Parameters:**
-- `topic` (required) - Topic to get instructions for:
-  - `code` - C# best practices, tool preferences
-  - `git` - Issue-first workflow, branch naming, commit format
-  - `tdd` - Test-driven development workflow
-  - `pre-pr` - Checklist before creating a pull request
-  - `tools` - Full Roslyn MCP tool preferences table
-
-**Output:**
-Returns the instructions as markdown text, ready to follow.
-
-**Usage:**
-Project CLAUDE.md files can be minimal - just pointing to these instructions:
-```markdown
-Before modifying C# code: roslyn_get_instructions(topic: "code")
-Before git operations: roslyn_get_instructions(topic: "git")
-```
-
-This keeps instructions up-to-date with the MCP server version.
-
-## Key Concepts
-
-### MCP Protocol
-- Uses **stdio transport** (stdin/stdout for communication)
-- Messages are **JSON-RPC 2.0** format, one JSON object per line
-- Server must not write to stdout except for MCP responses
-- Use stderr for logging/diagnostics
-
-### Tool Naming Convention
-- All tools prefixed with `roslyn_` to avoid conflicts with other MCP servers
-- Use snake_case: `roslyn_get_projects_in_build_order`, `roslyn_find_symbols`
+**Default branch:** `rc/1.0.1` (all PRs target here)
+
+For full workflow details: `roslyn_get_instructions(topic: "git")`
+
+Quick reference:
+1. Create issue: `gh issue create --title "..." --label "enhancement"`
+2. Create branch: `git checkout -b issues/N`
+3. Make changes with TDD
+4. Verify: `roslyn_get_diagnostics(severityFilter: "error")`
+5. Commit, push, create PR
 
 ## Architecture Notes
 
-### McpServer.cs
-- Handles JSON-RPC protocol parsing
-- Routes methods to handlers: `initialize`, `tools/list`, `tools/call`, etc.
-- Tool registration via `RegisterTool(name, definition, handler)`
-- Returns `{ content: [{ type: "text", text: "..." }], isError?: bool }`
+### MCP Protocol
+- Uses stdio transport (stdin/stdout)
+- JSON-RPC 2.0 format
+- All tools prefixed with `roslyn_`
 
-### RoslynTools (partial class, 3 files)
-- **RoslynTools.cs** - Core registration, echo, server info, projects tool
-- **RoslynTools.FindSymbol.cs** - Symbol search tool
-- **RoslynTools.References.cs** - Find references tool
-- Each tool has: name, description, JSON schema, annotations, async handler
+### Adding a New Tool
 
-### SolutionAnalyzerService (partial class, 4 files)
-- **SolutionAnalyzerService.cs** - MSBuild init, `GetProjectsInBuildOrderAsync()`
-- **SolutionAnalyzerService.Symbols.cs** - `FindSymbolsAsync()` + helpers
-- **SolutionAnalyzerService.References.cs** - `FindReferencesAsync()` + filtering
-- **SolutionAnalyzerService.Implementations.cs** - `FindImplementationsAsync()`
-
-### Models.cs
-- All DTOs: `ProjectBuildOrderResult`, `FindSymbolResult`, `FindReferencesResult`, etc.
-
-## Adding a New Tool
-
-1. Add the tool registration in `RoslynTools.cs`:
-```csharp
-private static void RegisterYourTool(McpServer server)
-{
-    server.RegisterTool(
-        "roslyn_your_tool",
-        new ToolDefinition
-        {
-            Description = "...",
-            InputSchema = new { type = "object", properties = new { ... } },
-            Annotations = new ToolAnnotations { ReadOnlyHint = true }
-        },
-        async args =>
-        {
-            // Your logic here
-            return new { content = new[] { new { type = "text", text = result } } };
-        });
-}
-```
-
-2. Call `RegisterYourTool(server)` in `RegisterAll()`.
+1. Create `RoslynTools.YourTool.cs` with `RegisterYourToolTool(McpServer server)`
+2. Call it from `RegisterAll()` in `RoslynTools.cs`
+3. Add service method to `SolutionAnalyzerService.YourTool.cs` if needed
+4. Update `Instructions/Topics/tools.md`
+5. Add tests in `RoslynMcpServer.Tests/`
 
 ## Roadmap
 
-### High Priority Tools
-- [x] `roslyn_get_callers` - Find callers of a method (impact analysis) ✓ Implemented
-- [ ] `roslyn_extract_method` - Extract code block into new method
-- [ ] `roslyn_change_signature` - Add/remove/reorder parameters with auto-fix callers
-- [ ] `roslyn_get_document_symbols` - All symbols in a specific file
-- [ ] `roslyn_organize_usings` - Sort + remove unused usings
-- [ ] `roslyn_format_document` - Apply .editorconfig formatting
-- [ ] `roslyn_extract_interface` - Extract interface from class
-- [ ] `roslyn_inline` - Replace variable/method usages with actual code
+### Implemented
+- Symbol search, references, callers, implementations
+- Type members, method body read/update
+- Diagnostics with code fixes (single and batch)
+- Rename symbol
+- Call graph database with file change detection
+- Instruction templates and dynamic instructions
 
-### Medium Priority Tools
-- [ ] `roslyn_move_type_to_file` - Move class to its own .cs file
-- [ ] `roslyn_encapsulate_field` - Convert field to property with backing field
-- [ ] `roslyn_generate_constructor` - Create constructor from fields/properties
-- [ ] `roslyn_generate_equals_hashcode` - Override Equals/GetHashCode
-- [ ] `roslyn_pull_members_up` - Move members to base class
-- [ ] `roslyn_push_members_down` - Move members to derived classes
-- [ ] `roslyn_find_unused_code` - Find dead methods/classes
-- [ ] `roslyn_get_dependency_graph` - Analyze assembly/type dependencies
-
-### Infrastructure
-- [ ] Caching for compilation results
-- [ ] Progress reporting for large solutions
+### Planned
+- `roslyn_extract_method` - Extract code block into new method
+- `roslyn_change_signature` - Add/remove/reorder parameters
+- `roslyn_organize_usings` - Sort + remove unused
+- `roslyn_format_document` - Apply .editorconfig formatting

--- a/CLAUDE_TEMPLATE.md
+++ b/CLAUDE_TEMPLATE.md
@@ -1,62 +1,42 @@
-# CLAUDE.md Template for C# Projects
+# CLAUDE.md - C# Development with Roslyn MCP
 
-> **Setup Instructions:**
-> 1. Copy this file to your project root as `CLAUDE.md`
-> 2. Customize the "Project Overview" section
-> 3. Choose your workflow template (see below)
-> 4. Delete this intro section
-
----
-
-## Quick Setup (Recommended)
-
-Instead of manually maintaining instructions, use the Roslyn MCP server to get up-to-date guidance:
-
-```bash
-# Get a template suited to your workflow
-roslyn_get_template(template: "standard")   # Basic workflow
-roslyn_get_template(template: "tdd")        # Test-driven development
-roslyn_get_template(template: "team")       # Full team workflow with issues
-roslyn_get_template(template: "minimal")    # Just MCP pointers
-```
-
-Copy the returned content to your CLAUDE.md.
-
----
-
-# CLAUDE.md - Instructions for Claude Code
+> **What is this file?** This is a CLAUDE.md file - instructions that Claude reads automatically when you start a conversation. You don't need to run anything here. Claude will follow these instructions when working with your code.
+>
+> **Setup:** Copy this file to your project root as `CLAUDE.md` and customize the "Project Overview" section below.
 
 ## Project Overview
 
-<!-- Customize: Brief description of what this project does -->
+<!-- Customize this section for your project -->
+This is a C# project using the Roslyn MCP server for enhanced code analysis.
 
-## Tool Preferences
+## Instructions for Claude
 
-When working with C# files in .NET solutions, use Roslyn MCP tools.
+### Tool Preferences
 
-For full tool preferences: `roslyn_get_instructions(topic: "tools")`
+When working with C# files in this project, use Roslyn MCP tools instead of native tools:
 
-## Development Workflows
+| Task | Use This Tool | Instead Of |
+|------|---------------|------------|
+| Find a type or method | `roslyn_find_symbol` | Grep |
+| See class structure | `roslyn_get_type_members` | Read entire file |
+| Read a method's code | `roslyn_get_method_body` | Read entire file |
+| Edit a method | `roslyn_update_method` | Edit with text patterns |
+| Add a new member | `roslyn_add_member` | Edit to insert code |
+| Find all references | `roslyn_get_references` | Grep for text |
+| Find who calls a method | `roslyn_get_callers` | roslyn_get_references |
+| Check for errors | `roslyn_get_diagnostics` | dotnet build |
+| Fix a warning | `roslyn_apply_code_fix` | Manual edit |
+| Rename a symbol | `roslyn_rename_symbol` | Find/replace |
 
-Before modifying C# code:
-```
-roslyn_get_instructions(topic: "code")
-```
+For the complete tool reference, call `roslyn_get_instructions` with topic "tools".
 
-Before git operations (issues, branches, commits, PRs):
-```
-roslyn_get_instructions(topic: "git")
-```
+### Workflows
 
-Before creating a pull request:
-```
-roslyn_get_instructions(topic: "pre-pr")
-```
+Before performing these tasks, get the detailed instructions:
 
-For test-driven development workflow:
-```
-roslyn_get_instructions(topic: "tdd")
-```
+- **Modifying C# code**: Call `roslyn_get_instructions` with topic "code"
+- **Git operations**: Call `roslyn_get_instructions` with topic "git"
+- **Creating a PR**: Call `roslyn_get_instructions` with topic "pre-pr"
 
 ## Project Structure
 

--- a/Instructions/Templates/minimal.md
+++ b/Instructions/Templates/minimal.md
@@ -1,9 +1,21 @@
 # CLAUDE.md - C# Development with Roslyn MCP
 
-When working with C# code, use the Roslyn MCP server for guidance:
+> **What is this file?** This is a CLAUDE.md file - instructions that Claude reads automatically when you start a conversation. You don't need to run anything here. Claude will follow these instructions when working with your code.
 
-- Before modifying C# code: `roslyn_get_instructions(topic: "code")`
-- Before git operations: `roslyn_get_instructions(topic: "git")`
-- Before creating PR: `roslyn_get_instructions(topic: "pre-pr")`
+## Instructions for Claude
 
-Use Roslyn MCP tools (`roslyn_*`) instead of native tools (Grep, Read, Edit) for C# files.
+When working with C# code in this project, you have access to the Roslyn MCP server. Use these tools instead of native tools (Grep, Read, Edit) for C# files:
+
+| Task | Use This Tool |
+|------|---------------|
+| Find a type or method | `roslyn_find_symbol` |
+| Read a method's code | `roslyn_get_method_body` |
+| Edit a method | `roslyn_update_method` |
+| Find all references | `roslyn_get_references` |
+| Check for errors | `roslyn_get_diagnostics` |
+
+For detailed guidance on any topic, call the instruction tools:
+- Code modification best practices: call `roslyn_get_instructions` with topic "code"
+- Git workflow: call `roslyn_get_instructions` with topic "git"
+- Before creating a PR: call `roslyn_get_instructions` with topic "pre-pr"
+- Full tool reference: call `roslyn_get_instructions` with topic "tools"

--- a/Instructions/Templates/standard.md
+++ b/Instructions/Templates/standard.md
@@ -1,21 +1,32 @@
 # CLAUDE.md - C# Development with Roslyn MCP
 
-## Tool Preferences
+> **What is this file?** This is a CLAUDE.md file - instructions that Claude reads automatically when you start a conversation. You don't need to run anything here. Claude will follow these instructions when working with your code.
 
-When working with C# files in .NET solutions, prefer Roslyn MCP tools over native tools:
+## Instructions for Claude
 
-| Task | Use This | Not This |
-|------|----------|----------|
-| Find type/method | `roslyn_find_symbol` | Grep |
-| Read a method | `roslyn_get_method_body` | Read entire file |
+### Tool Preferences
+
+When working with C# files in this project, use Roslyn MCP tools instead of native tools:
+
+| Task | Use This Tool | Instead Of |
+|------|---------------|------------|
+| Find a type or method | `roslyn_find_symbol` | Grep |
+| See class structure | `roslyn_get_type_members` | Read entire file |
+| Read a method's code | `roslyn_get_method_body` | Read entire file |
 | Edit a method | `roslyn_update_method` | Edit with text patterns |
-| Find references | `roslyn_get_references` | Grep for text |
-| Check errors | `roslyn_get_diagnostics` | dotnet build |
+| Add a new member | `roslyn_add_member` | Edit to insert code |
+| Find all references | `roslyn_get_references` | Grep for text |
+| Find who calls a method | `roslyn_get_callers` | roslyn_get_references |
+| Check for errors | `roslyn_get_diagnostics` | dotnet build |
+| Fix a warning | `roslyn_apply_code_fix` | Manual edit |
+| Rename a symbol | `roslyn_rename_symbol` | Find/replace |
 
-For full tool preferences: `roslyn_get_instructions(topic: "tools")`
+For the complete tool reference, call `roslyn_get_instructions` with topic "tools".
 
-## Workflows
+### Workflows
 
-- Before modifying C# code: `roslyn_get_instructions(topic: "code")`
-- Before git operations: `roslyn_get_instructions(topic: "git")`
-- Before creating PR: `roslyn_get_instructions(topic: "pre-pr")`
+Before performing these tasks, get the detailed instructions:
+
+- **Modifying C# code**: Call `roslyn_get_instructions` with topic "code"
+- **Git operations**: Call `roslyn_get_instructions` with topic "git"
+- **Creating a PR**: Call `roslyn_get_instructions` with topic "pre-pr"

--- a/Instructions/Templates/tdd.md
+++ b/Instructions/Templates/tdd.md
@@ -1,31 +1,38 @@
 # CLAUDE.md - C# Development with Roslyn MCP (TDD)
 
-## Test-Driven Development
+> **What is this file?** This is a CLAUDE.md file - instructions that Claude reads automatically when you start a conversation. You don't need to run anything here. Claude will follow these instructions when working with your code.
 
-**YOU MUST follow TDD for ALL code changes. No exceptions.**
+## Instructions for Claude
+
+### Test-Driven Development (REQUIRED)
+
+**You MUST follow TDD for ALL code changes in this project. No exceptions.**
 
 1. Write FAILING test(s) first
 2. Run tests - verify they FAIL
 3. Write minimum code to make tests PASS
 4. Refactor if needed (tests must still pass)
 
-For full TDD workflow: `roslyn_get_instructions(topic: "tdd")`
+For the complete TDD workflow, call `roslyn_get_instructions` with topic "tdd".
 
-## Tool Preferences
+### Tool Preferences
 
-When working with C# files, prefer Roslyn MCP tools:
+When working with C# files, use Roslyn MCP tools instead of native tools:
 
-| Task | Use This | Not This |
-|------|----------|----------|
-| Find type/method | `roslyn_find_symbol` | Grep |
-| Read a method | `roslyn_get_method_body` | Read entire file |
+| Task | Use This Tool | Instead Of |
+|------|---------------|------------|
+| Find a type or method | `roslyn_find_symbol` | Grep |
+| See class structure | `roslyn_get_type_members` | Read entire file |
+| Read a method's code | `roslyn_get_method_body` | Read entire file |
 | Edit a method | `roslyn_update_method` | Edit with text patterns |
-| Check errors | `roslyn_get_diagnostics` | dotnet build |
+| Check for errors | `roslyn_get_diagnostics` | dotnet build |
 
-For full tool preferences: `roslyn_get_instructions(topic: "tools")`
+For the complete tool reference, call `roslyn_get_instructions` with topic "tools".
 
-## Workflows
+### Workflows
 
-- Before modifying C# code: `roslyn_get_instructions(topic: "code")`
-- Before git operations: `roslyn_get_instructions(topic: "git")`
-- Before creating PR: `roslyn_get_instructions(topic: "pre-pr")`
+Before performing these tasks, get the detailed instructions:
+
+- **Modifying C# code**: Call `roslyn_get_instructions` with topic "code"
+- **Git operations**: Call `roslyn_get_instructions` with topic "git"
+- **Creating a PR**: Call `roslyn_get_instructions` with topic "pre-pr"

--- a/Instructions/Templates/team.md
+++ b/Instructions/Templates/team.md
@@ -1,36 +1,48 @@
 # CLAUDE.md - C# Development with Roslyn MCP (Team Workflow)
 
-## Issue-First Development
+> **What is this file?** This is a CLAUDE.md file - instructions that Claude reads automatically when you start a conversation. You don't need to run anything here. Claude will follow these instructions when working with your code.
+
+## Instructions for Claude
+
+### Issue-First Development (REQUIRED)
 
 **NEVER write code without a GitHub issue.**
 
-1. Create GitHub issue first describing the feature/bug
-2. Create feature branch: `issues/N`
-3. Reference issue in commits: `Fixes #N`
+1. Create a GitHub issue first describing the feature or bug
+2. Create a feature branch: `issues/N` (where N is the issue number)
+3. Reference the issue in commits: `Fixes #N`
 
-For full git workflow: `roslyn_get_instructions(topic: "git")`
+For the complete git workflow, call `roslyn_get_instructions` with topic "git".
 
-## Test-Driven Development
+### Test-Driven Development (REQUIRED)
 
-**YOU MUST follow TDD for ALL code changes.**
+**You MUST follow TDD for ALL code changes. No exceptions.**
 
-For full TDD workflow: `roslyn_get_instructions(topic: "tdd")`
+1. Write FAILING test(s) first
+2. Run tests - verify they FAIL
+3. Write minimum code to make tests PASS
+4. Refactor if needed (tests must still pass)
 
-## Tool Preferences
+For the complete TDD workflow, call `roslyn_get_instructions` with topic "tdd".
 
-When working with C# files, prefer Roslyn MCP tools:
+### Tool Preferences
 
-| Task | Use This | Not This |
-|------|----------|----------|
-| Find type/method | `roslyn_find_symbol` | Grep |
-| Read a method | `roslyn_get_method_body` | Read entire file |
+When working with C# files, use Roslyn MCP tools instead of native tools:
+
+| Task | Use This Tool | Instead Of |
+|------|---------------|------------|
+| Find a type or method | `roslyn_find_symbol` | Grep |
+| See class structure | `roslyn_get_type_members` | Read entire file |
+| Read a method's code | `roslyn_get_method_body` | Read entire file |
 | Edit a method | `roslyn_update_method` | Edit with text patterns |
-| Check errors | `roslyn_get_diagnostics` | dotnet build |
+| Check for errors | `roslyn_get_diagnostics` | dotnet build |
 
-For full tool preferences: `roslyn_get_instructions(topic: "tools")`
+For the complete tool reference, call `roslyn_get_instructions` with topic "tools".
 
-## Workflows
+### Workflows
 
-- Before modifying C# code: `roslyn_get_instructions(topic: "code")`
-- Before git operations: `roslyn_get_instructions(topic: "git")`
-- Before creating PR: `roslyn_get_instructions(topic: "pre-pr")`
+Before performing these tasks, get the detailed instructions:
+
+- **Modifying C# code**: Call `roslyn_get_instructions` with topic "code"
+- **Git operations**: Call `roslyn_get_instructions` with topic "git"
+- **Creating a PR**: Call `roslyn_get_instructions` with topic "pre-pr"

--- a/Instructions/Topics/code.md
+++ b/Instructions/Topics/code.md
@@ -23,6 +23,7 @@ Follow these steps before modifying any C# code:
 - Use `roslyn_get_type_members` to see all members of the class
 - Use `roslyn_get_method_body` to read the specific method
 - Use `roslyn_get_callers` to understand who calls this code
+- For large codebases, use `roslyn_query_graph` for faster recursive caller analysis
 
 ### 3. VERIFY the scope
 - If file > 300 lines, plan to extract helper classes
@@ -49,6 +50,7 @@ Choose the right tool for each task:
 | Add new member | `roslyn_add_member` |
 | Find all usages | `roslyn_get_references` |
 | Find who calls this | `roslyn_get_callers` |
+| Find callers recursively | `roslyn_query_graph` (needs `roslyn_graph_analyze` first) |
 | Find implementations | `roslyn_get_implementations` |
 | Check for errors | `roslyn_get_diagnostics` |
 | Fix a warning | `roslyn_apply_code_fix` |

--- a/Instructions/Topics/git.md
+++ b/Instructions/Topics/git.md
@@ -7,9 +7,17 @@ You are performing git operations in a project that follows issue-first developm
 ## Critical Rules
 
 - NEVER write code without a GitHub issue
-- NEVER use `git push --force` on main/master
+- NEVER push directly to the default branch
+- NEVER use `git push --force` on main/master/release branches
 - NEVER use `git commit --amend` unless explicitly requested
 - NEVER skip hooks (`--no-verify`)
+
+## Before Starting
+
+Get the default branch name:
+```bash
+gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+```
 
 ## Workflow
 
@@ -17,51 +25,75 @@ Follow these steps for any code change:
 
 ### 1. CREATE ISSUE (if not exists)
 ```bash
-gh issue create --title "Brief description" --body "Details" --label "bug|enhancement"
+gh issue create --title "Type: Brief description" --body "Details" --label "bug"
 ```
 Note the issue number (e.g., #42)
 
+Labels: `bug`, `enhancement`, `documentation`, `refactor`
+
 ### 2. CREATE BRANCH
 ```bash
+git checkout <default-branch>
+git pull
 git checkout -b issues/42
 ```
 Branch name format: `issues/N` where N is issue number
 
 ### 3. MAKE CHANGES
-- Follow TDD if required: `roslyn_get_instructions(topic: "tdd")`
-- Use Roslyn tools for C# changes: `roslyn_get_instructions(topic: "code")`
+- Follow TDD if required: call `roslyn_get_instructions` with topic "tdd"
+- Use Roslyn tools for C# changes: call `roslyn_get_instructions` with topic "code"
 
-### 4. VERIFY BUILD
-```
-roslyn_get_diagnostics(severityFilter: "error")
-```
+### 4. PRE-PR CHECKLIST
+Before creating a PR, complete the checklist: call `roslyn_get_instructions` with topic "pre-pr"
 
 ### 5. COMMIT
 ```bash
 git add -A
-git commit -m "Fix: description
+git commit -m "$(cat <<'EOF'
+Type: brief description
+
+Detailed explanation if needed.
 
 Fixes #42
 
-Co-Authored-By: Claude <noreply@anthropic.com>"
+Co-Authored-By: Claude <noreply@anthropic.com>
+EOF
+)"
 ```
 
-### 6. PUSH AND PR
+### 6. PUSH AND CREATE PR
 ```bash
 git push -u origin issues/42
-gh pr create --base rc/X.X.X --title "Fix: description" --body "Fixes #42"
+gh pr create --base <default-branch> --title "Type: description" --body "$(cat <<'EOF'
+## Summary
+- Brief description of changes
+
+## Test plan
+- [ ] All tests pass
+- [ ] No new errors or warnings
+
+Fixes #42
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
 ```
 
-## Commit Format
-
-Use this commit message format:
+## Commit Message Format
 
 ```
 Type: brief description
+
+Optional detailed explanation.
 
 Fixes #N
 
 Co-Authored-By: Claude <noreply@anthropic.com>
 ```
 
-Types: Fix, Feature, Refactor, Docs, Test
+**Types:**
+- `Fix` - Bug fix
+- `Feature` - New functionality
+- `Refactor` - Code restructuring
+- `Docs` - Documentation only
+- `Test` - Adding or updating tests

--- a/Instructions/Topics/pre-pr.md
+++ b/Instructions/Topics/pre-pr.md
@@ -2,33 +2,31 @@
 
 ## Context
 
-You are about to create a pull request. Complete this checklist to ensure code quality.
+You are about to create a pull request. **You MUST complete this checklist before creating a PR.**
 
 ## Checklist
 
-Complete these steps before creating a PR:
-
 ### 1. CHECK FOR ERRORS
 ```
-roslyn_get_diagnostics(severityFilter: "error")
+roslyn_get_diagnostics(solutionPath, severityFilter: "error")
 ```
 Result must show: `totalErrors: 0`
 
-If errors exist, fix them before proceeding.
+**If errors exist, fix them before proceeding.**
 
 ### 2. CHECK FOR WARNINGS
 ```
-roslyn_get_diagnostics(severityFilter: "warning")
+roslyn_get_diagnostics(solutionPath, severityFilter: "warning")
 ```
 Review warnings. Fix any that are reasonable.
 
-Use `roslyn_batch_apply_code_fixes` for bulk fixes.
+Use `roslyn_batch_apply_code_fixes` for bulk fixes when available.
 
 ### 3. RUN TESTS
 ```bash
 dotnet test
 ```
-All tests must pass.
+**All tests must pass.** Do not create a PR with failing tests.
 
 ### 4. VERIFY CHANGES
 ```bash
@@ -36,19 +34,28 @@ git status
 git diff HEAD
 ```
 - Ensure all intended changes are staged
-- Ensure no unintended files are included
+- Ensure no unintended files are included (secrets, build artifacts, etc.)
 
-### 5. CREATE PR
+### 5. GET DEFAULT BRANCH
 ```bash
-gh pr create --base rc/X.X.X --title "Type: description" --body "$(cat <<'EOF'
+gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+```
+Use this as the `--base` for the PR.
+
+### 6. CREATE PR
+```bash
+gh pr create --base <default-branch> --title "Type: description" --body "$(cat <<'EOF'
 ## Summary
 - Brief description of changes
 
-## Test Plan
-- [ ] Unit tests pass
-- [ ] Manual testing done (if applicable)
+## Test plan
+- [ ] All tests pass (`dotnet test`)
+- [ ] No compilation errors (`roslyn_get_diagnostics`)
+- [ ] Warnings reviewed
 
 Fixes #N
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF
 )"
 ```
@@ -57,9 +64,14 @@ EOF
 
 Use: `Type: brief description`
 
-Types: Fix, Feature, Refactor, Docs, Test
+**Types:**
+- `Fix` - Bug fix
+- `Feature` - New functionality
+- `Refactor` - Code restructuring
+- `Docs` - Documentation only
+- `Test` - Adding or updating tests
 
-Examples:
+**Examples:**
 - `Fix: Null reference in UserService.Save`
 - `Feature: Add retry logic to API client`
-- `Refactor: Extract validation to separate class`
+- `Docs: Improve README for new users`

--- a/Instructions/Topics/tools.md
+++ b/Instructions/Topics/tools.md
@@ -4,9 +4,59 @@
 
 You have access to Roslyn MCP tools for C# code analysis. These tools provide semantic understanding of code, unlike text-based search.
 
-## Tool Selection Guide
+## All Available Tools
 
-Use this guide to select the right tool:
+### Code Navigation & Understanding
+
+| Tool | Purpose |
+|------|---------|
+| `roslyn_find_symbol` | Find types, methods, properties by name pattern |
+| `roslyn_get_type_members` | See all members of a class (methods, properties, fields) |
+| `roslyn_get_method_body` | Read full source code of a specific method |
+| `roslyn_get_references` | Find all references to a symbol |
+| `roslyn_get_callers` | Find who calls a method (call sites only) |
+| `roslyn_get_implementations` | Find implementations of interface or derived classes |
+
+### Code Modification
+
+| Tool | Purpose |
+|------|---------|
+| `roslyn_update_method` | Replace a method's implementation |
+| `roslyn_add_member` | Add new method/property/field to a type |
+| `roslyn_rename_symbol` | Rename across entire solution |
+
+### Diagnostics & Fixes
+
+| Tool | Purpose |
+|------|---------|
+| `roslyn_get_diagnostics` | Get compiler errors and warnings |
+| `roslyn_apply_code_fix` | Apply Roslyn's suggested fix for one diagnostic |
+| `roslyn_batch_apply_code_fixes` | Fix all diagnostics of a specific type |
+
+### Call Graph (Cached Analysis)
+
+| Tool | Purpose |
+|------|---------|
+| `roslyn_graph_status` | Check if call graph exists for solution |
+| `roslyn_graph_analyze` | Build/update call graph database |
+| `roslyn_query_graph` | Query callers/callees with recursive depth |
+
+### Solution & Project
+
+| Tool | Purpose |
+|------|---------|
+| `roslyn_get_projects_in_build_order` | List projects in dependency order |
+| `roslyn_get_server_info` | Server version and capabilities |
+| `roslyn_echo` | Test connectivity |
+
+### Instructions
+
+| Tool | Purpose |
+|------|---------|
+| `roslyn_get_template` | Get CLAUDE.md template for projects |
+| `roslyn_get_instructions` | Get topic-specific development instructions |
+
+## Tool Selection Guide
 
 | Task | Roslyn Tool | Why NOT native tool |
 |------|-------------|---------------------|
@@ -17,6 +67,7 @@ Use this guide to select the right tool:
 | Add new member | `roslyn_add_member` | Edit doesn't format or place correctly |
 | Find usages | `roslyn_get_references` | Grep finds text matches, not usages |
 | Find callers | `roslyn_get_callers` | References includes non-calls |
+| Find callers (large codebase) | `roslyn_query_graph` | Faster with cached graph |
 | Find implementations | `roslyn_get_implementations` | Grep can't follow inheritance |
 | Check errors | `roslyn_get_diagnostics` | dotnet build output is harder to parse |
 | Fix warning | `roslyn_apply_code_fix` | Manual edit may introduce errors |
@@ -42,6 +93,11 @@ Use native tools (Read, Edit, Grep, Glob) only for:
 1. `roslyn_find_symbol(pattern)` → locate the symbol
 2. `roslyn_get_callers(filePath, line, column)` → see who calls it
 3. Assess impact before changing signature
+
+### Impact analysis (large codebase)
+1. `roslyn_graph_analyze(solutionPath)` → build/update call graph (first time)
+2. `roslyn_query_graph(symbolName, direction: "callers", maxDepth: 3)` → find all callers recursively
+3. Much faster than `roslyn_get_callers` for repeated queries
 
 ### Fixing compiler warnings
 1. `roslyn_get_diagnostics(severityFilter: "warning")` → see all warnings

--- a/README.md
+++ b/README.md
@@ -1,42 +1,37 @@
 # Roslyn MCP Server
 
-A **Model Context Protocol (MCP) server** that provides deep C# code analysis capabilities using Microsoft's Roslyn compiler platform. Enables AI assistants like Claude to understand, navigate, and modify .NET codebases with semantic precision.
+A server that gives Claude deep understanding of your C# code using Microsoft's Roslyn compiler.
 
-## Why Use This?
+## What Is This?
 
-**For C# developers:** This server gives Claude "IDE superpowers" for your .NET code. Instead of treating code as text, Claude can:
+When you use **Claude Code** (Anthropic's AI coding assistant for the terminal), it normally treats your code as text. This works, but it can:
+- Find the wrong `Save` method when you search for "Save"
+- Read entire 2000-line files just to see one method
+- Break code when doing find/replace refactoring
 
-| Without Roslyn MCP | With Roslyn MCP |
-|-------------------|-----------------|
-| `grep "Save"` finds 50 matches | `roslyn_find_symbol` finds the exact `UserService.Save()` method |
-| Reading a 2000-line file to find one method | `roslyn_get_method_body` returns just that method |
-| `Edit` pattern matches wrong code | `roslyn_update_method` targets exactly one method |
-| Manual find/replace breaks code | `roslyn_rename_symbol` updates all references correctly |
+**Roslyn MCP Server** gives Claude the same understanding of C# that your IDE has. It knows `User` the class is different from `user` the variable.
 
-**The key insight:** Roslyn (the C# compiler) understands your code semantically. It knows `User` the class is different from `user` the variable. This MCP server exposes that understanding to Claude.
-
-### Real-World Benefits
-
-- **Large codebases** - Navigate 100+ file solutions without reading everything
-- **Safe refactoring** - Rename symbols, find all usages, understand impact
-- **Precise edits** - Modify one method in a 2000-line file without pattern ambiguity
-- **Code health** - Find and auto-fix warnings (CS* and CA* rules) across the solution
+| Without This Server | With This Server |
+|---------------------|------------------|
+| `grep "Save"` finds 50 text matches | Finds the exact `UserService.Save()` method |
+| Reads whole file to find one method | Returns just that method |
+| Find/replace can match wrong code | Targets exactly the right symbol |
 
 ## Prerequisites
 
-- **.NET 10.0 SDK** or later
-- **Visual Studio 2022** or **Build Tools** (for MSBuild)
-- **Claude Code** CLI
+Before you start, you need:
 
-## Features
+1. **.NET 10.0 SDK** - [Download from Microsoft](https://dotnet.microsoft.com/download)
+2. **Visual Studio 2022** (any edition) or **Build Tools for Visual Studio** - needed for MSBuild
+3. **Claude Code CLI** - Anthropic's terminal-based AI assistant. Install with:
+   ```bash
+   npm install -g @anthropic-ai/claude-code
+   ```
+   Then authenticate: `claude` and follow the prompts.
 
-- **Semantic Code Analysis** - Uses Roslyn compiler for accurate symbol resolution
-- **Built-in .NET Analyzers** - Includes Microsoft.CodeAnalysis.NetAnalyzers for CA* rules (CA1806, CA2000, etc.)
-- **Self-contained** - All analyzer DLLs are bundled with the server on build
+## Quick Start (5 Steps)
 
-## Quick Start
-
-### 1. Clone and Build
+### Step 1: Download and Build the Server
 
 ```bash
 git clone https://github.com/BeinerChes/RoslynMcpServer.git
@@ -44,13 +39,11 @@ cd RoslynMcpServer
 dotnet build
 ```
 
-### 2. Configure Claude Code
+Note the full path to the RoslynMcpServer folder (e.g., `C:\Dev\RoslynMcpServer`). You'll need it in Step 2.
 
-Add the server to your Claude Code MCP configuration. You have two options:
+### Step 2: Tell Claude Code About the Server
 
-#### Option A: Project-level config (recommended)
-
-Create `.mcp.json` in your project root:
+Create a file called `.mcp.json` in your C# project's root folder (where your `.sln` file is):
 
 ```json
 {
@@ -58,60 +51,81 @@ Create `.mcp.json` in your project root:
     "roslyn": {
       "type": "stdio",
       "command": "dotnet",
-      "args": ["run", "--project", "C:\\path\\to\\RoslynMcpServer"]
+      "args": ["run", "--project", "C:\\Dev\\RoslynMcpServer"]
     }
   }
 }
 ```
 
-#### Option B: Global config
+**Important:** Replace `C:\\Dev\\RoslynMcpServer` with the actual path from Step 1. Use double backslashes on Windows.
 
-Add to your global Claude Code settings (`~/.claude/settings.json`):
+### Step 3: Add Instructions for Claude
 
-```json
-{
-  "mcpServers": {
-    "roslyn": {
-      "type": "stdio",
-      "command": "dotnet",
-      "args": ["run", "--project", "C:\\path\\to\\RoslynMcpServer"]
-    }
-  }
-}
+Create a file called `CLAUDE.md` in your project root. This file tells Claude HOW to work with your code.
+
+**Option A: Get a template from the server** (recommended)
+
+Start Claude Code in your project folder, then ask:
+```
+Get the standard template using roslyn_get_template
 ```
 
-### 3. Connect in Claude Code
+Claude will fetch the template and you can save it as CLAUDE.md.
 
+**Option B: Download directly**
 ```bash
-# Start Claude Code in your .NET project directory
-claude
-
-# The roslyn server should connect automatically
-# Verify with:
-/mcp
-```
-
-If you need to reconnect:
-```
-/mcp reconnect roslyn
-```
-
-### 4. Configure CLAUDE.md (Important!)
-
-Add a `CLAUDE.md` file to your project root to instruct Claude to use Roslyn tools instead of native file operations.
-
-**Quick start:** Copy the template from this repository:
-```bash
-# From your project directory
 curl -o CLAUDE.md https://raw.githubusercontent.com/BeinerChes/RoslynMcpServer/rc/1.0.0/CLAUDE_TEMPLATE.md
 ```
 
-Or manually copy `CLAUDE_TEMPLATE.md` from this repository and customize it for your project.
+**What is CLAUDE.md?** It's a file that Claude reads to understand your project's conventions. With Roslyn MCP, it tells Claude to use Roslyn tools instead of basic text search/replace. You don't execute anything in this file - Claude reads it automatically.
 
-**Why is this important?** Without `CLAUDE.md`, Claude may default to native `Read`/`Edit` tools which:
-- Use text patterns that can match the wrong code
-- Read entire files when you only need one method
-- Miss overloads and type context
+### Step 4: Start Claude Code
+
+Open a terminal in your project folder and run:
+```bash
+claude
+```
+
+The Roslyn server should connect automatically. You'll see it listed when you type `/mcp`.
+
+### Step 5: Verify It's Working
+
+Ask Claude:
+```
+Find all types containing "Controller" in this solution
+```
+
+If it uses `roslyn_find_symbol`, everything is working. If it uses `grep`, check that:
+- The `.mcp.json` file is in your project root
+- The path to RoslynMcpServer is correct
+- The `CLAUDE.md` file exists
+
+## Available Templates
+
+The server provides different CLAUDE.md templates for different workflows:
+
+| Template | Best For | Get It |
+|----------|----------|--------|
+| `minimal` | Quick setup, basic Roslyn tools | `roslyn_get_template(template: "minimal")` |
+| `standard` | Most projects - tools + git workflow | `roslyn_get_template(template: "standard")` |
+| `tdd` | Test-driven development teams | `roslyn_get_template(template: "tdd")` |
+| `team` | Full workflow with issues + TDD | `roslyn_get_template(template: "team")` |
+
+Ask Claude to fetch any template: "Get the tdd template using roslyn_get_template"
+
+## Why CLAUDE.md Matters
+
+Without `CLAUDE.md`, Claude uses basic file operations:
+- Reads entire files with `cat` or `Read`
+- Searches with `grep` (finds text, not symbols)
+- Edits with pattern matching (can match wrong code)
+
+With `CLAUDE.md` pointing to Roslyn tools:
+- Reads just the method you need
+- Searches semantically (finds the right `Save()` method)
+- Edits precisely (modifies exactly one method)
+
+The CLAUDE.md file is instructions **for Claude to read**, not commands for you to run. You create it once and Claude follows it automatically.
 
 ## Available Tools
 
@@ -203,157 +217,6 @@ Rename the GetData method in DataService to FetchDataAsync
 ```
 
 Claude will use `roslyn_rename_symbol` to safely rename the method and update all references across the solution.
-
-## Tool Details
-
-### roslyn_find_symbol
-
-```json
-{
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "pattern": "FeatureLayer",
-  "symbolKind": "type",
-  "matchType": "contains",
-  "maxResults": 50
-}
-```
-
-**symbolKind**: `all`, `type`, `member`, `namespace`, `typeAndMember`
-**matchType**: `exact`, `exactIgnoreCase`, `contains`, `prefix`, `suffix`
-
-### roslyn_get_method_body
-
-```json
-{
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "typeName": "FeatureLayer",
-  "methodName": "BuildCachedData",
-  "parameterTypes": "CancellationToken, bool"
-}
-```
-
-Use `parameterTypes` to select specific overloads.
-
-### roslyn_update_method
-
-```json
-{
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "typeName": "FeatureLayer",
-  "methodName": "BuildCachedData",
-  "parameterTypes": "CancellationToken, bool",
-  "newSourceCode": "private void BuildCachedData(...) { /* new impl */ }"
-}
-```
-
-### roslyn_add_member
-
-```json
-{
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "typeName": "CacheManager",
-  "memberCode": "public void Dispose() { _cache.Clear(); }",
-  "insertionPoint": "end"
-}
-```
-
-**insertionPoint**: `start`, `end`, `after-fields`, `after-constructors`, `after-properties`, `before-methods`
-Default: smart placement based on member type.
-
-### roslyn_get_diagnostics
-
-```json
-{
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "severityFilter": "warning",
-  "projectFilter": "MyApp.Core"
-}
-```
-
-Without `diagnosticId`: returns summary with counts per diagnostic code.
-With `diagnosticId`: returns detailed entries with file/line/method info.
-
-### roslyn_apply_code_fix
-
-```json
-{
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "filePath": "C:\\path\\to\\MyClass.cs",
-  "line": 42,
-  "column": 13,
-  "diagnosticId": "CS0168",
-  "fixIndex": 0,
-  "preview": false
-}
-```
-
-**Workflow:**
-1. Use `roslyn_get_diagnostics` to find issues
-2. Use `roslyn_apply_code_fix` with `preview: true` to see what would change
-3. Apply the fix with `preview: false`
-
-If multiple fixes are available, the tool returns the list. Specify `fixIndex` to select one.
-
-### roslyn_batch_apply_code_fixes
-
-```json
-{
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "diagnosticId": "CS0168",
-  "projectFilter": "MyProject",
-  "maxFixes": 100,
-  "preview": false
-}
-```
-
-**Workflow:**
-1. Use `roslyn_get_diagnostics` to find issues (note `fixAvailable: true` in summary)
-2. Use `roslyn_batch_apply_code_fixes` with `preview: true` to see what would change
-3. Apply fixes with `preview: false`
-4. Verify with `roslyn_get_diagnostics` again
-
-**When to use:**
-- **Batch**: Fix all occurrences of a warning type (e.g., all CS0168 unused variables)
-- **Single**: Fix one diagnostic, or choose between multiple fix options
-
-### roslyn_rename_symbol
-
-```json
-{
-  "solutionPath": "C:\\path\\to\\solution.sln",
-  "filePath": "C:\\path\\to\\DataService.cs",
-  "line": 15,
-  "column": 22,
-  "newName": "FetchDataAsync"
-}
-```
-
-**Workflow:**
-1. Use `roslyn_find_symbol` to locate the symbol you want to rename
-2. Call `roslyn_rename_symbol` with the file path, line, column, and new name
-3. The tool applies the rename immediately and returns a list of affected files
-
-The tool updates all references across the entire solution automatically.
-
-## WPF/XAML Support
-
-As of version 1.0.0, the server fully supports WPF/XAML projects.
-
-**How it works:**
-
-1. Before loading a solution, the server detects WPF projects (by checking for `UseWPF=true` or WPF references)
-2. For each WPF project, it runs a **design-time build** to generate `*.g.cs` files
-3. This uses MSBuild's `MarkupCompilePass1` and `MarkupCompilePass2` targets - the same mechanism Visual Studio uses
-4. Generated files are then included in the Roslyn compilation
-
-**Benefits:**
-- Works even if the project has never been built before
-- No false positive errors for `InitializeComponent` or `x:Name` elements
-- Same behavior as Visual Studio's IntelliSense
-
-**Note:** The first analysis of a WPF project may take a few extra seconds while the design-time build runs.
-
-See [GitHub issue #11](https://github.com/BeinerChes/RoslynMcpServer/issues/11) for details
 
 ## Troubleshooting
 
@@ -452,10 +315,11 @@ MIT
 
 | File | Purpose |
 |------|---------|
-| `CLAUDE.md` | Development guidelines for this repository |
-| `CLAUDE_TEMPLATE.md` | **Copy this to your projects** - Template for using Roslyn MCP |
-| `README.md` | This file |
+| `README.md` | This file - how to install and use the server |
+| `CLAUDE_TEMPLATE.md` | **Copy this to your projects** as `CLAUDE.md` - tells Claude to use Roslyn tools |
+| `CLAUDE.md` | Instructions for developing this repository itself (not for end users) |
+| `.mcp.json` | Example MCP configuration for Claude Code |
 
 ## Contributing
 
-Issues and PRs welcome! See `CLAUDE.md` for development guidelines.
+Issues and PRs welcome. See `CLAUDE.md` for development guidelines for this repository.


### PR DESCRIPTION
## Summary
- Rewrite README Getting Started with clear 5-step setup
- Add prerequisites section explaining .NET SDK, Visual Studio, and Claude Code
- Explain what MCP and Claude Code are for new users
- Add "What is this file?" explanation to all 4 templates
- Update CLAUDE_TEMPLATE.md with clearer instructions
- Update tools.md with all 20 available tools (including graph tools)
- Simplify CLAUDE.md to use MCP instruction pointers (1099 → 123 lines)

## Test plan
- [ ] README steps are clear and actionable
- [ ] Templates explain they're for Claude to read, not for users to execute
- [ ] All 20 tools listed in tools.md

Fixes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)