### PR TITLE
Docs: Make git workflow mandatory in CLAUDE.md and templates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,122 +1,93 @@
 # CLAUDE.md - Instructions for Claude Code
 
+## Solution Path
+
+**Solution file:** `C:\Users\beine\source\repos\RoslynMcpServer\RoslynMcpServer.slnx`
+
+Use this path for all `roslyn_*` tool calls.
+
+## MANDATORY: Git Workflow for ALL Code Changes
+
+**You MUST follow this workflow for ANY code change. No exceptions.**
+
+### Before writing ANY code:
+1. **Create GitHub issue:** `gh issue create --title "Type: description" --label "bug|enhancement|documentation"`
+2. **Create branch:** `git checkout -b issues/N` (where N is issue number)
+
+### After making changes:
+3. **Check for errors:** `roslyn_get_diagnostics(solutionPath, severityFilter: "error")`
+4. **Run tests:** `dotnet test` - all must pass
+5. **Commit:** `git add -A && git commit -m "Type: description\n\nFixes #N\n\nCo-Authored-By: Claude <noreply@anthropic.com>"`
+6. **Push and create PR:** `git push -u origin issues/N && gh pr create --base rc/1.0.1 --title "Type: description" --body "Fixes #N"`
+7. **Merge and cleanup:** `gh pr merge --squash --delete-branch && git checkout rc/1.0.1 && git pull`
+
+**For detailed instructions:** Call `roslyn_get_instructions` with topic "git"
+
+## Tool Preferences
+
+Use Roslyn MCP tools for C# files:
+
+| Task | Use This |
+|------|----------|
+| Find type/method | `roslyn_find_symbol` |
+| See class structure | `roslyn_get_type_members` |
+| Read a method | `roslyn_get_method_body` |
+| Edit a method | `roslyn_update_method` |
+| Add new member | `roslyn_add_member` |
+| Find references | `roslyn_get_references` |
+| Find callers | `roslyn_get_callers` |
+| Check errors | `roslyn_get_diagnostics` |
+| Fix warnings | `roslyn_apply_code_fix` or `roslyn_batch_apply_code_fixes` |
+| Rename symbol | `roslyn_rename_symbol` |
+
+**For full tool reference:** Call `roslyn_get_instructions` with topic "tools"
+
 ## Project Overview
 
 This is a **Model Context Protocol (MCP) server** written in C# (.NET 10.0) that provides C# solution analysis capabilities using Microsoft's Roslyn compiler platform.
 
-The server enables AI assistants to analyze .NET solutions with deep semantic understanding - finding symbols, tracking references, understanding call graphs, and more.
-
-## Development Guidelines
-
-For C# code modifications: `roslyn_get_instructions(topic: "code")`
-For git workflow: `roslyn_get_instructions(topic: "git")`
-For TDD workflow: `roslyn_get_instructions(topic: "tdd")`
-Before creating PR: `roslyn_get_instructions(topic: "pre-pr")`
-For all available tools: `roslyn_get_instructions(topic: "tools")`
-
 ## Project-Specific Rules
 
-### IMPORTANT: Maintain Instruction Files
+### Maintain Instruction Files
 
-When adding new tools, **YOU MUST update `Instructions/Topics/tools.md`**.
-
-Also update `CLAUDE_TEMPLATE.md` if the tool is user-facing.
+When adding new tools, **YOU MUST update `Instructions/Topics/tools.md`** and `CLAUDE_TEMPLATE.md`.
 
 ### Code Guidelines
 
-- Keep .cs files under 300 lines (extract helper classes if needed)
+- Keep .cs files under 300 lines
 - Use C# 12 features (primary constructors, collection expressions)
 - Use `async/await` for all I/O operations
 - All logging goes to stderr (`Console.Error.WriteLine`)
 
 ### Test Requirements
 
-- Every code change MUST have an associated GitHub issue
-- Every feature/fix MUST have unit tests with issue reference comment
+- Every code change MUST have unit tests
 - Follow TDD: write failing tests BEFORE implementation
-
-## Tech Stack
-
-- **.NET 10.0** - Target framework
-- **Microsoft.CodeAnalysis** - Roslyn code analysis
-- **Microsoft.Build.Locator** - MSBuild discovery
-- **xUnit** - Unit testing
-- **SQLite** (via RoslynMcpServer.Graph) - Call graph caching
-
-## Project Structure
-
-```
-RoslynMcpServer/
-├── CLAUDE.md                 # This file
-├── Instructions/             # External instruction files (copied to output)
-│   ├── Templates/            # CLAUDE.md templates for users
-│   └── Topics/               # Topic-specific instructions
-├── src/
-│   ├── McpServer.cs          # MCP protocol implementation
-│   ├── RoslynTools*.cs       # Tool registrations (partial classes)
-│   ├── SolutionAnalyzerService*.cs  # Roslyn analysis (partial classes)
-│   ├── Instructions.cs       # Reads instruction files
-│   └── Models*.cs            # DTOs
-├── RoslynMcpServer.Graph/    # Call graph database project
-└── RoslynMcpServer.Tests/    # xUnit tests
-```
 
 ## Build & Test
 
 ```bash
 dotnet build           # Build
 dotnet test            # Run tests
-dotnet run             # Run MCP server
 ```
 
 ### Rebuilding After Code Changes
 
-The MCP server runs as a background process:
-
+The MCP server runs as a background process. To rebuild:
 1. Kill running process: `taskkill //F //PID <pid>`
 2. Rebuild: `dotnet build`
-3. Reconnect in Claude Code: `/mcp` → reconnect roslyn
+3. Reconnect: `/mcp` → reconnect roslyn
 
-## Git Workflow
+## Project Structure
 
-**Default branch:** `rc/1.0.1` (all PRs target here)
-
-For full workflow details: `roslyn_get_instructions(topic: "git")`
-
-Quick reference:
-1. Create issue: `gh issue create --title "..." --label "enhancement"`
-2. Create branch: `git checkout -b issues/N`
-3. Make changes with TDD
-4. Verify: `roslyn_get_diagnostics(severityFilter: "error")`
-5. Commit, push, create PR
-
-## Architecture Notes
-
-### MCP Protocol
-- Uses stdio transport (stdin/stdout)
-- JSON-RPC 2.0 format
-- All tools prefixed with `roslyn_`
-
-### Adding a New Tool
-
-1. Create `RoslynTools.YourTool.cs` with `RegisterYourToolTool(McpServer server)`
-2. Call it from `RegisterAll()` in `RoslynTools.cs`
-3. Add service method to `SolutionAnalyzerService.YourTool.cs` if needed
-4. Update `Instructions/Topics/tools.md`
-5. Add tests in `RoslynMcpServer.Tests/`
-
-## Roadmap
-
-### Implemented
-- Symbol search, references, callers, implementations
-- Type members, method body read/update
-- Diagnostics with code fixes (single and batch)
-- Rename symbol
-- Call graph database with file change detection
-- Instruction templates and dynamic instructions
-
-### Planned
-- `roslyn_extract_method` - Extract code block into new method
-- `roslyn_change_signature` - Add/remove/reorder parameters
-- `roslyn_organize_usings` - Sort + remove unused
-- `roslyn_format_document` - Apply .editorconfig formatting
+```
+RoslynMcpServer/
+├── RoslynMcpServer.slnx      # Solution file (use this path!)
+├── CLAUDE.md                 # This file
+├── Instructions/             # Instruction files (copied to output)
+│   ├── Templates/            # CLAUDE.md templates for users
+│   └── Topics/               # Topic-specific instructions
+├── src/                      # Source code
+├── RoslynMcpServer.Graph/    # Call graph database project
+└── RoslynMcpServer.Tests/    # xUnit tests
+```

--- a/CLAUDE_TEMPLATE.md
+++ b/CLAUDE_TEMPLATE.md
@@ -2,41 +2,53 @@
 
 > **What is this file?** This is a CLAUDE.md file - instructions that Claude reads automatically when you start a conversation. You don't need to run anything here. Claude will follow these instructions when working with your code.
 >
-> **Setup:** Copy this file to your project root as `CLAUDE.md` and customize the "Project Overview" section below.
+> **Setup:** Copy this file to your project root as `CLAUDE.md` and update the solution path below.
 
-## Project Overview
+## Solution Path
 
-<!-- Customize this section for your project -->
-This is a C# project using the Roslyn MCP server for enhanced code analysis.
+<!-- UPDATE THIS to your solution file path -->
+**Solution file:** `C:\path\to\YourProject.sln`
 
-## Instructions for Claude
+Use this path for all `roslyn_*` tool calls.
 
-### Tool Preferences
+## MANDATORY: Git Workflow for Code Changes
 
-When working with C# files in this project, use Roslyn MCP tools instead of native tools:
+**You MUST follow this workflow for ANY code change. No exceptions.**
 
-| Task | Use This Tool | Instead Of |
-|------|---------------|------------|
-| Find a type or method | `roslyn_find_symbol` | Grep |
-| See class structure | `roslyn_get_type_members` | Read entire file |
-| Read a method's code | `roslyn_get_method_body` | Read entire file |
-| Edit a method | `roslyn_update_method` | Edit with text patterns |
-| Add a new member | `roslyn_add_member` | Edit to insert code |
-| Find all references | `roslyn_get_references` | Grep for text |
-| Find who calls a method | `roslyn_get_callers` | roslyn_get_references |
-| Check for errors | `roslyn_get_diagnostics` | dotnet build |
-| Fix a warning | `roslyn_apply_code_fix` | Manual edit |
-| Rename a symbol | `roslyn_rename_symbol` | Find/replace |
+1. **Create GitHub issue:** `gh issue create --title "Type: description" --label "bug|enhancement"`
+2. **Create branch:** `git checkout -b issues/N`
+3. **Make changes** using Roslyn tools
+4. **Check for errors:** `roslyn_get_diagnostics(solutionPath, severityFilter: "error")`
+5. **Run tests:** `dotnet test`
+6. **Commit, push, create PR, merge:**
+   ```bash
+   git add -A && git commit -m "Type: description - Fixes #N"
+   git push -u origin issues/N
+   gh pr create --base main --title "Type: description" --body "Fixes #N"
+   gh pr merge --squash --delete-branch
+   git checkout main && git pull
+   ```
 
-For the complete tool reference, call `roslyn_get_instructions` with topic "tools".
+**For detailed git instructions:** Call `roslyn_get_instructions` with topic "git"
 
-### Workflows
+## Tool Preferences
 
-Before performing these tasks, get the detailed instructions:
+Use Roslyn MCP tools for C# files:
 
-- **Modifying C# code**: Call `roslyn_get_instructions` with topic "code"
-- **Git operations**: Call `roslyn_get_instructions` with topic "git"
-- **Creating a PR**: Call `roslyn_get_instructions` with topic "pre-pr"
+| Task | Use This |
+|------|----------|
+| Find type/method | `roslyn_find_symbol` |
+| See class structure | `roslyn_get_type_members` |
+| Read a method | `roslyn_get_method_body` |
+| Edit a method | `roslyn_update_method` |
+| Add new member | `roslyn_add_member` |
+| Find references | `roslyn_get_references` |
+| Find callers | `roslyn_get_callers` |
+| Check errors | `roslyn_get_diagnostics` |
+| Fix warnings | `roslyn_apply_code_fix` |
+| Rename symbol | `roslyn_rename_symbol` |
+
+**For full tool reference:** Call `roslyn_get_instructions` with topic "tools"
 
 ## Project Structure
 
@@ -45,10 +57,8 @@ Before performing these tasks, get the detailed instructions:
 YourProject/
 ├── CLAUDE.md                 # This file
 ├── YourProject.sln           # Solution file
-├── src/
-│   └── YourProject/          # Main project
-└── tests/
-    └── YourProject.Tests/    # Test project
+├── src/                      # Source code
+└── tests/                    # Test projects
 ```
 
 ## Build Commands
@@ -56,7 +66,4 @@ YourProject/
 ```bash
 dotnet build        # Build
 dotnet test         # Run tests
-dotnet run          # Run the application
 ```
-
-<!-- Add any project-specific commands here -->

--- a/Instructions/Templates/minimal.md
+++ b/Instructions/Templates/minimal.md
@@ -1,21 +1,26 @@
 # CLAUDE.md - C# Development with Roslyn MCP
 
-> **What is this file?** This is a CLAUDE.md file - instructions that Claude reads automatically when you start a conversation. You don't need to run anything here. Claude will follow these instructions when working with your code.
+> **What is this file?** This is a CLAUDE.md file - instructions that Claude reads automatically. You don't run anything here.
 
-## Instructions for Claude
+## Solution Path
 
-When working with C# code in this project, you have access to the Roslyn MCP server. Use these tools instead of native tools (Grep, Read, Edit) for C# files:
+<!-- UPDATE THIS to your solution file path -->
+**Solution file:** `C:\path\to\YourProject.sln`
 
-| Task | Use This Tool |
-|------|---------------|
-| Find a type or method | `roslyn_find_symbol` |
-| Read a method's code | `roslyn_get_method_body` |
+Use this path for all `roslyn_*` tool calls.
+
+## Tool Preferences
+
+Use Roslyn MCP tools for C# files:
+
+| Task | Use This |
+|------|----------|
+| Find type/method | `roslyn_find_symbol` |
+| Read a method | `roslyn_get_method_body` |
 | Edit a method | `roslyn_update_method` |
-| Find all references | `roslyn_get_references` |
-| Check for errors | `roslyn_get_diagnostics` |
+| Find references | `roslyn_get_references` |
+| Check errors | `roslyn_get_diagnostics` |
 
-For detailed guidance on any topic, call the instruction tools:
-- Code modification best practices: call `roslyn_get_instructions` with topic "code"
-- Git workflow: call `roslyn_get_instructions` with topic "git"
-- Before creating a PR: call `roslyn_get_instructions` with topic "pre-pr"
-- Full tool reference: call `roslyn_get_instructions` with topic "tools"
+**For full tool reference:** Call `roslyn_get_instructions` with topic "tools"
+
+**For code modification guidelines:** Call `roslyn_get_instructions` with topic "code"

--- a/Instructions/Templates/standard.md
+++ b/Instructions/Templates/standard.md
@@ -1,32 +1,49 @@
 # CLAUDE.md - C# Development with Roslyn MCP
 
-> **What is this file?** This is a CLAUDE.md file - instructions that Claude reads automatically when you start a conversation. You don't need to run anything here. Claude will follow these instructions when working with your code.
+> **What is this file?** This is a CLAUDE.md file - instructions that Claude reads automatically. You don't run anything here.
 
-## Instructions for Claude
+## Solution Path
 
-### Tool Preferences
+<!-- UPDATE THIS to your solution file path -->
+**Solution file:** `C:\path\to\YourProject.sln`
 
-When working with C# files in this project, use Roslyn MCP tools instead of native tools:
+Use this path for all `roslyn_*` tool calls.
 
-| Task | Use This Tool | Instead Of |
-|------|---------------|------------|
-| Find a type or method | `roslyn_find_symbol` | Grep |
-| See class structure | `roslyn_get_type_members` | Read entire file |
-| Read a method's code | `roslyn_get_method_body` | Read entire file |
-| Edit a method | `roslyn_update_method` | Edit with text patterns |
-| Add a new member | `roslyn_add_member` | Edit to insert code |
-| Find all references | `roslyn_get_references` | Grep for text |
-| Find who calls a method | `roslyn_get_callers` | roslyn_get_references |
-| Check for errors | `roslyn_get_diagnostics` | dotnet build |
-| Fix a warning | `roslyn_apply_code_fix` | Manual edit |
-| Rename a symbol | `roslyn_rename_symbol` | Find/replace |
+## MANDATORY: Git Workflow for Code Changes
 
-For the complete tool reference, call `roslyn_get_instructions` with topic "tools".
+**You MUST follow this workflow for ANY code change. No exceptions.**
 
-### Workflows
+1. **Create GitHub issue:** `gh issue create --title "Type: description" --label "bug|enhancement"`
+2. **Create branch:** `git checkout -b issues/N`
+3. **Make changes** using Roslyn tools
+4. **Check for errors:** `roslyn_get_diagnostics(solutionPath, severityFilter: "error")`
+5. **Run tests:** `dotnet test`
+6. **Commit, push, create PR, merge:**
+   ```bash
+   git add -A && git commit -m "Type: description - Fixes #N"
+   git push -u origin issues/N
+   gh pr create --base main --title "Type: description" --body "Fixes #N"
+   gh pr merge --squash --delete-branch
+   git checkout main && git pull
+   ```
 
-Before performing these tasks, get the detailed instructions:
+**For detailed git instructions:** Call `roslyn_get_instructions` with topic "git"
 
-- **Modifying C# code**: Call `roslyn_get_instructions` with topic "code"
-- **Git operations**: Call `roslyn_get_instructions` with topic "git"
-- **Creating a PR**: Call `roslyn_get_instructions` with topic "pre-pr"
+## Tool Preferences
+
+Use Roslyn MCP tools for C# files:
+
+| Task | Use This |
+|------|----------|
+| Find type/method | `roslyn_find_symbol` |
+| See class structure | `roslyn_get_type_members` |
+| Read a method | `roslyn_get_method_body` |
+| Edit a method | `roslyn_update_method` |
+| Add new member | `roslyn_add_member` |
+| Find references | `roslyn_get_references` |
+| Find callers | `roslyn_get_callers` |
+| Check errors | `roslyn_get_diagnostics` |
+| Fix warnings | `roslyn_apply_code_fix` |
+| Rename symbol | `roslyn_rename_symbol` |
+
+**For full tool reference:** Call `roslyn_get_instructions` with topic "tools"

--- a/Instructions/Templates/tdd.md
+++ b/Instructions/Templates/tdd.md
@@ -1,38 +1,54 @@
 # CLAUDE.md - C# Development with Roslyn MCP (TDD)
 
-> **What is this file?** This is a CLAUDE.md file - instructions that Claude reads automatically when you start a conversation. You don't need to run anything here. Claude will follow these instructions when working with your code.
+> **What is this file?** This is a CLAUDE.md file - instructions that Claude reads automatically. You don't run anything here.
 
-## Instructions for Claude
+## Solution Path
 
-### Test-Driven Development (REQUIRED)
+<!-- UPDATE THIS to your solution file path -->
+**Solution file:** `C:\path\to\YourProject.sln`
 
-**You MUST follow TDD for ALL code changes in this project. No exceptions.**
+Use this path for all `roslyn_*` tool calls.
+
+## MANDATORY: Git Workflow for Code Changes
+
+**You MUST follow this workflow for ANY code change. No exceptions.**
+
+1. **Create GitHub issue:** `gh issue create --title "Type: description" --label "bug|enhancement"`
+2. **Create branch:** `git checkout -b issues/N`
+3. **Write FAILING tests first** (TDD - see below)
+4. **Implement code** to make tests pass
+5. **Check for errors:** `roslyn_get_diagnostics(solutionPath, severityFilter: "error")`
+6. **Run tests:** `dotnet test` - all must pass
+7. **Commit, push, create PR, merge:**
+   ```bash
+   git add -A && git commit -m "Type: description - Fixes #N"
+   git push -u origin issues/N
+   gh pr create --base main --title "Type: description" --body "Fixes #N"
+   gh pr merge --squash --delete-branch
+   git checkout main && git pull
+   ```
+
+## MANDATORY: Test-Driven Development
+
+**You MUST follow TDD for ALL code changes.**
 
 1. Write FAILING test(s) first
 2. Run tests - verify they FAIL
 3. Write minimum code to make tests PASS
 4. Refactor if needed (tests must still pass)
 
-For the complete TDD workflow, call `roslyn_get_instructions` with topic "tdd".
+**For detailed TDD instructions:** Call `roslyn_get_instructions` with topic "tdd"
 
-### Tool Preferences
+## Tool Preferences
 
-When working with C# files, use Roslyn MCP tools instead of native tools:
+Use Roslyn MCP tools for C# files:
 
-| Task | Use This Tool | Instead Of |
-|------|---------------|------------|
-| Find a type or method | `roslyn_find_symbol` | Grep |
-| See class structure | `roslyn_get_type_members` | Read entire file |
-| Read a method's code | `roslyn_get_method_body` | Read entire file |
-| Edit a method | `roslyn_update_method` | Edit with text patterns |
-| Check for errors | `roslyn_get_diagnostics` | dotnet build |
+| Task | Use This |
+|------|----------|
+| Find type/method | `roslyn_find_symbol` |
+| See class structure | `roslyn_get_type_members` |
+| Read a method | `roslyn_get_method_body` |
+| Edit a method | `roslyn_update_method` |
+| Check errors | `roslyn_get_diagnostics` |
 
-For the complete tool reference, call `roslyn_get_instructions` with topic "tools".
-
-### Workflows
-
-Before performing these tasks, get the detailed instructions:
-
-- **Modifying C# code**: Call `roslyn_get_instructions` with topic "code"
-- **Git operations**: Call `roslyn_get_instructions` with topic "git"
-- **Creating a PR**: Call `roslyn_get_instructions` with topic "pre-pr"
+**For full tool reference:** Call `roslyn_get_instructions` with topic "tools"

--- a/Instructions/Templates/team.md
+++ b/Instructions/Templates/team.md
@@ -1,48 +1,63 @@
 # CLAUDE.md - C# Development with Roslyn MCP (Team Workflow)
 
-> **What is this file?** This is a CLAUDE.md file - instructions that Claude reads automatically when you start a conversation. You don't need to run anything here. Claude will follow these instructions when working with your code.
+> **What is this file?** This is a CLAUDE.md file - instructions that Claude reads automatically. You don't run anything here.
 
-## Instructions for Claude
+## Solution Path
 
-### Issue-First Development (REQUIRED)
+<!-- UPDATE THIS to your solution file path -->
+**Solution file:** `C:\path\to\YourProject.sln`
 
-**NEVER write code without a GitHub issue.**
+Use this path for all `roslyn_*` tool calls.
 
-1. Create a GitHub issue first describing the feature or bug
-2. Create a feature branch: `issues/N` (where N is the issue number)
-3. Reference the issue in commits: `Fixes #N`
+## MANDATORY: Git Workflow for ALL Code Changes
 
-For the complete git workflow, call `roslyn_get_instructions` with topic "git".
+**You MUST follow this workflow for ANY code change. No exceptions.**
 
-### Test-Driven Development (REQUIRED)
+### Before writing ANY code:
+1. **Create GitHub issue:** `gh issue create --title "Type: description" --label "bug|enhancement"`
+2. **Create branch:** `git checkout -b issues/N`
 
-**You MUST follow TDD for ALL code changes. No exceptions.**
+### Development (with TDD):
+3. **Write FAILING tests first**
+4. **Implement code** to make tests pass
+5. **Check for errors:** `roslyn_get_diagnostics(solutionPath, severityFilter: "error")`
+6. **Run tests:** `dotnet test` - all must pass
+
+### After changes complete:
+7. **Commit:** `git add -A && git commit -m "Type: description - Fixes #N"`
+8. **Push:** `git push -u origin issues/N`
+9. **Create PR:** `gh pr create --base main --title "Type: description" --body "Fixes #N"`
+10. **Merge:** `gh pr merge --squash --delete-branch`
+11. **Update local:** `git checkout main && git pull`
+
+**For detailed git instructions:** Call `roslyn_get_instructions` with topic "git"
+
+## MANDATORY: Test-Driven Development
+
+**You MUST follow TDD for ALL code changes.**
 
 1. Write FAILING test(s) first
 2. Run tests - verify they FAIL
 3. Write minimum code to make tests PASS
 4. Refactor if needed (tests must still pass)
 
-For the complete TDD workflow, call `roslyn_get_instructions` with topic "tdd".
+**For detailed TDD instructions:** Call `roslyn_get_instructions` with topic "tdd"
 
-### Tool Preferences
+## Tool Preferences
 
-When working with C# files, use Roslyn MCP tools instead of native tools:
+Use Roslyn MCP tools for C# files:
 
-| Task | Use This Tool | Instead Of |
-|------|---------------|------------|
-| Find a type or method | `roslyn_find_symbol` | Grep |
-| See class structure | `roslyn_get_type_members` | Read entire file |
-| Read a method's code | `roslyn_get_method_body` | Read entire file |
-| Edit a method | `roslyn_update_method` | Edit with text patterns |
-| Check for errors | `roslyn_get_diagnostics` | dotnet build |
+| Task | Use This |
+|------|----------|
+| Find type/method | `roslyn_find_symbol` |
+| See class structure | `roslyn_get_type_members` |
+| Read a method | `roslyn_get_method_body` |
+| Edit a method | `roslyn_update_method` |
+| Add new member | `roslyn_add_member` |
+| Find references | `roslyn_get_references` |
+| Find callers | `roslyn_get_callers` |
+| Check errors | `roslyn_get_diagnostics` |
+| Fix warnings | `roslyn_apply_code_fix` |
+| Rename symbol | `roslyn_rename_symbol` |
 
-For the complete tool reference, call `roslyn_get_instructions` with topic "tools".
-
-### Workflows
-
-Before performing these tasks, get the detailed instructions:
-
-- **Modifying C# code**: Call `roslyn_get_instructions` with topic "code"
-- **Git operations**: Call `roslyn_get_instructions` with topic "git"
-- **Creating a PR**: Call `roslyn_get_instructions` with topic "pre-pr"
+**For full tool reference:** Call `roslyn_get_instructions` with topic "tools"


### PR DESCRIPTION
## Summary
- Add solution path section to all templates (users must update this)
- Make git workflow MANDATORY with explicit step-by-step instructions
- Add solution path to this repo's CLAUDE.md
- Simplify and clarify all templates

## Test plan
- [x] All tests pass (`dotnet test`)
- [x] No compilation errors

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)