### PR TITLE
Refactor: Rename FindSymbolsAsync to SearchSymbolsAsync

### DIFF
--- a/src/RoslynTools.FindSymbol.cs
+++ b/src/RoslynTools.FindSymbol.cs
@@ -116,7 +116,7 @@ public static partial class RoslynTools
                     _ => MatchType.Contains
                 };
 
-                var result = await _analyzerService!.FindSymbolsAsync(
+                var result = await _analyzerService!.SearchSymbolsAsync(
                     solutionPath,
                     pattern,
                     symbolKind,

--- a/src/SolutionAnalyzerService.Symbols.cs
+++ b/src/SolutionAnalyzerService.Symbols.cs
@@ -9,7 +9,7 @@ public partial class SolutionAnalyzerService
     /// <summary>
     /// Finds symbols in a solution by name pattern.
     /// </summary>
-    public async Task<FindSymbolResult> FindSymbolsAsync(
+    public async Task<FindSymbolResult> SearchSymbolsAsync(
         string solutionPath,
         string pattern,
         SymbolKindFilter kindFilter = SymbolKindFilter.All,


### PR DESCRIPTION
## Summary
- Renamed `FindSymbolsAsync` method to `SearchSymbolsAsync` in `SolutionAnalyzerService`
- Updated all references in `RoslynTools.FindSymbol.cs`

Fixes #28