### PR TITLE
Fix: Support partial symbol name matching in graph tools

### DIFF
--- a/RoslynMcpServer.Graph/GraphDatabase.Symbols.cs
+++ b/RoslynMcpServer.Graph/GraphDatabase.Symbols.cs
@@ -40,7 +40,7 @@ public sealed partial class GraphDatabase
     }
 
     /// <summary>
-    /// Gets a symbol by its qualified name.
+    /// Gets a symbol by its qualified name (exact match).
     /// </summary>
     public async Task<SymbolRecord?> GetSymbolByQualifiedNameAsync(long solutionId, string qualifiedName)
     {
@@ -53,6 +53,59 @@ public sealed partial class GraphDatabase
             WHERE SolutionId = @SolutionId AND QualifiedName = @QualifiedName
             """,
             new { SolutionId = solutionId, QualifiedName = qualifiedName });
+    }
+
+    /// <summary>
+    /// Finds a symbol by partial name with smart matching.
+    /// Supports: exact match, method name only, Type.Method, or partial namespace.
+    /// Returns error with candidates if multiple matches found.
+    /// Issue: #33
+    /// </summary>
+    public async Task<SymbolSearchResult> FindSymbolAsync(long solutionId, string searchName)
+    {
+        if (_connection == null) throw new InvalidOperationException("Database not open");
+
+        // 1. Try exact match first
+        var exact = await GetSymbolByQualifiedNameAsync(solutionId, searchName);
+        if (exact != null)
+        {
+            return new SymbolSearchResult { Symbol = exact };
+        }
+
+        // 2. Try partial matching - search for symbols ending with the search term
+        // This handles: "MethodName", "Type.MethodName", "Namespace.Type.MethodName"
+        var candidates = await _connection.QueryAsync<SymbolRecord>(
+            """
+            SELECT Id, SolutionId, Kind, Name, QualifiedName, FilePath, Line, Column, BodyHash, ContainingTypeId, Status, LastAnalyzed
+            FROM Symbols
+            WHERE SolutionId = @SolutionId
+              AND (QualifiedName LIKE '%.' || @SearchName || '(%'
+                   OR QualifiedName LIKE '%.' || @SearchName
+                   OR Name = @SearchName)
+            """,
+            new { SolutionId = solutionId, SearchName = searchName });
+
+        var matches = candidates.ToList();
+
+        if (matches.Count == 0)
+        {
+            return new SymbolSearchResult
+            {
+                Error = $"Symbol '{searchName}' not found in graph."
+            };
+        }
+
+        if (matches.Count == 1)
+        {
+            return new SymbolSearchResult { Symbol = matches[0] };
+        }
+
+        // Multiple matches - return error with candidates
+        return new SymbolSearchResult
+        {
+            Error = $"Multiple symbols match '{searchName}'. Please be more specific.",
+            Candidates = matches
+        };
     }
 
     /// <summary>
@@ -173,4 +226,26 @@ public sealed class SymbolStats
     public int Analyzed { get; set; }
     public int Pending { get; set; }
     public int Dirty { get; set; }
+}
+
+/// <summary>
+/// Result of a symbol search operation.
+/// Issue: #33
+/// </summary>
+public sealed class SymbolSearchResult
+{
+    /// <summary>
+    /// The found symbol (null if not found or ambiguous).
+    /// </summary>
+    public SymbolRecord? Symbol { get; set; }
+
+    /// <summary>
+    /// Error message if symbol not found or ambiguous.
+    /// </summary>
+    public string? Error { get; set; }
+
+    /// <summary>
+    /// List of candidates when multiple symbols match.
+    /// </summary>
+    public List<SymbolRecord>? Candidates { get; set; }
 }

--- a/RoslynMcpServer.Tests/Graph/GraphSymbolSearchTests.cs
+++ b/RoslynMcpServer.Tests/Graph/GraphSymbolSearchTests.cs
@@ -1,0 +1,185 @@
+using RoslynMcpServer.Graph;
+
+namespace RoslynMcpServer.Tests.Graph;
+
+/// <summary>
+/// Tests for partial symbol name matching in GraphDatabase.
+/// Issue: #33
+/// </summary>
+public class GraphSymbolSearchTests : IAsyncLifetime
+{
+    private GraphDatabase _db = null!;
+    private SolutionRecord _solution = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = GraphDatabase.CreateInMemory();
+        await _db.OpenAsync();
+        _solution = await _db.GetOrCreateSolutionAsync(@"C:\test\MySolution.sln");
+
+        // Create test symbols with full qualified names (like Roslyn generates)
+        await _db.InsertSymbolAsync(new SymbolRecord
+        {
+            SolutionId = _solution.Id,
+            Kind = SymbolKind.Method,
+            Name = "GetCallersAsync",
+            QualifiedName = "MyApp.Services.UserService.GetCallersAsync(string, int)",
+            FilePath = @"C:\test\UserService.cs",
+            Line = 10,
+            Column = 5
+        });
+
+        await _db.InsertSymbolAsync(new SymbolRecord
+        {
+            SolutionId = _solution.Id,
+            Kind = SymbolKind.Method,
+            Name = "GetCallersAsync",
+            QualifiedName = "MyApp.Services.OrderService.GetCallersAsync()",
+            FilePath = @"C:\test\OrderService.cs",
+            Line = 20,
+            Column = 5
+        });
+
+        await _db.InsertSymbolAsync(new SymbolRecord
+        {
+            SolutionId = _solution.Id,
+            Kind = SymbolKind.Method,
+            Name = "SaveAsync",
+            QualifiedName = "MyApp.Services.UserService.SaveAsync(MyApp.Models.User)",
+            FilePath = @"C:\test\UserService.cs",
+            Line = 30,
+            Column = 5
+        });
+
+        await _db.InsertSymbolAsync(new SymbolRecord
+        {
+            SolutionId = _solution.Id,
+            Kind = SymbolKind.Property,
+            Name = "Name",
+            QualifiedName = "MyApp.Models.User.Name",
+            FilePath = @"C:\test\User.cs",
+            Line = 5,
+            Column = 5
+        });
+    }
+
+    public Task DisposeAsync()
+    {
+        _db.Dispose();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Tests that exact qualified name match still works.
+    /// Issue: #33
+    /// </summary>
+    [Fact]
+    public async Task FindSymbolAsync_ExactMatch_ReturnsSymbol()
+    {
+        // Act
+        var result = await _db.FindSymbolAsync(
+            _solution.Id,
+            "MyApp.Services.UserService.GetCallersAsync(string, int)");
+
+        // Assert
+        Assert.NotNull(result.Symbol);
+        Assert.Equal("GetCallersAsync", result.Symbol.Name);
+        Assert.Null(result.Error);
+    }
+
+    /// <summary>
+    /// Tests that method name only finds matching symbols.
+    /// Issue: #33
+    /// </summary>
+    [Fact]
+    public async Task FindSymbolAsync_MethodNameOnly_FindsMatches()
+    {
+        // Act
+        var result = await _db.FindSymbolAsync(_solution.Id, "SaveAsync");
+
+        // Assert
+        Assert.NotNull(result.Symbol);
+        Assert.Equal("SaveAsync", result.Symbol.Name);
+    }
+
+    /// <summary>
+    /// Tests that Type.Method pattern finds the right symbol.
+    /// Issue: #33
+    /// </summary>
+    [Fact]
+    public async Task FindSymbolAsync_TypeDotMethod_FindsSymbol()
+    {
+        // Act
+        var result = await _db.FindSymbolAsync(_solution.Id, "UserService.GetCallersAsync");
+
+        // Assert
+        Assert.NotNull(result.Symbol);
+        Assert.Contains("UserService", result.Symbol.QualifiedName);
+        Assert.Equal("GetCallersAsync", result.Symbol.Name);
+    }
+
+    /// <summary>
+    /// Tests that ambiguous name returns error with options.
+    /// Issue: #33
+    /// </summary>
+    [Fact]
+    public async Task FindSymbolAsync_AmbiguousName_ReturnsErrorWithOptions()
+    {
+        // Act - "GetCallersAsync" exists in both UserService and OrderService
+        var result = await _db.FindSymbolAsync(_solution.Id, "GetCallersAsync");
+
+        // Assert
+        Assert.Null(result.Symbol);
+        Assert.NotNull(result.Error);
+        Assert.Contains("Multiple", result.Error);
+        Assert.NotNull(result.Candidates);
+        Assert.Equal(2, result.Candidates.Count);
+    }
+
+    /// <summary>
+    /// Tests that non-existent symbol returns appropriate error.
+    /// Issue: #33
+    /// </summary>
+    [Fact]
+    public async Task FindSymbolAsync_NotFound_ReturnsError()
+    {
+        // Act
+        var result = await _db.FindSymbolAsync(_solution.Id, "NonExistentMethod");
+
+        // Assert
+        Assert.Null(result.Symbol);
+        Assert.NotNull(result.Error);
+        Assert.Contains("not found", result.Error.ToLower());
+    }
+
+    /// <summary>
+    /// Tests that partial namespace matching works.
+    /// Issue: #33
+    /// </summary>
+    [Fact]
+    public async Task FindSymbolAsync_PartialNamespace_FindsSymbol()
+    {
+        // Act
+        var result = await _db.FindSymbolAsync(_solution.Id, "Services.UserService.SaveAsync");
+
+        // Assert
+        Assert.NotNull(result.Symbol);
+        Assert.Equal("SaveAsync", result.Symbol.Name);
+    }
+
+    /// <summary>
+    /// Tests property lookup by simple name.
+    /// Issue: #33
+    /// </summary>
+    [Fact]
+    public async Task FindSymbolAsync_PropertyName_FindsProperty()
+    {
+        // Act
+        var result = await _db.FindSymbolAsync(_solution.Id, "User.Name");
+
+        // Assert
+        Assert.NotNull(result.Symbol);
+        Assert.Equal("Name", result.Symbol.Name);
+        Assert.Equal(SymbolKind.Property, result.Symbol.Kind);
+    }
+}

--- a/src/RoslynTools.Graph.cs
+++ b/src/RoslynTools.Graph.cs
@@ -313,15 +313,23 @@ public static partial class RoslynTools
             };
         }
 
-        var symbol = await db.GetSymbolByQualifiedNameAsync(solution.Id, symbolName);
-        if (symbol == null)
+        // Use FindSymbolAsync for partial name matching (Issue #33)
+        var searchResult = await db.FindSymbolAsync(solution.Id, symbolName);
+        if (searchResult.Symbol == null)
         {
+            var error = searchResult.Error ?? $"Symbol '{symbolName}' not found in graph.";
+            if (searchResult.Candidates != null && searchResult.Candidates.Count > 0)
+            {
+                error += " Did you mean: " + string.Join(", ", searchResult.Candidates.Take(5).Select(c => c.QualifiedName));
+            }
             return new GraphQueryResult
             {
                 Success = false,
-                Error = $"Symbol '{symbolName}' not found in graph."
+                Error = error
             };
         }
+
+        var symbol = searchResult.Symbol;
 
         // Collect all file paths to check for staleness
         var filesToCheck = new HashSet<string> { symbol.FilePath };
@@ -368,8 +376,8 @@ public static partial class RoslynTools
         // Re-query to get fresh results if any files were refreshed
         if (refreshedFiles.Count > 0)
         {
-            symbol = await db.GetSymbolByQualifiedNameAsync(solution.Id, symbolName);
-            if (symbol == null)
+            var refreshResult = await db.FindSymbolAsync(solution.Id, symbolName);
+            if (refreshResult.Symbol == null)
             {
                 return new GraphQueryResult
                 {
@@ -377,6 +385,7 @@ public static partial class RoslynTools
                     Error = $"Symbol '{symbolName}' not found after refresh."
                 };
             }
+            symbol = refreshResult.Symbol;
         }
 
         var result = new GraphQueryResult

--- a/src/RoslynTools.GraphImpact.cs
+++ b/src/RoslynTools.GraphImpact.cs
@@ -165,15 +165,23 @@ public static partial class RoslynTools
             };
         }
 
-        var symbol = await db.GetSymbolByQualifiedNameAsync(solution.Id, symbolName);
-        if (symbol == null)
+        // Use FindSymbolAsync for partial name matching (Issue #33)
+        var searchResult = await db.FindSymbolAsync(solution.Id, symbolName);
+        if (searchResult.Symbol == null)
         {
+            var error = searchResult.Error ?? $"Symbol '{symbolName}' not found in graph.";
+            if (searchResult.Candidates != null && searchResult.Candidates.Count > 0)
+            {
+                error += " Did you mean: " + string.Join(", ", searchResult.Candidates.Take(5).Select(c => c.QualifiedName));
+            }
             return new GraphImpactResult
             {
                 Success = false,
-                Error = $"Symbol '{symbolName}' not found in graph. Run roslyn_graph_analyze first."
+                Error = error
             };
         }
+
+        var symbol = searchResult.Symbol;
 
         // Get all transitive callers
         var allCallers = await db.GetRecursiveCallersAsync(symbol.Id, maxDepth);


### PR DESCRIPTION
## Summary
- Added `FindSymbolAsync` method to `GraphDatabase` for partial symbol name matching
- Supports: exact match, method name only, Type.Method, partial namespace
- Returns helpful error with candidates when multiple matches found
- Updated `roslyn_query_graph` and `roslyn_graph_impact` tools to use the new matching

Fixes #33

## Test plan
- [x] Added 7 new tests for partial symbol matching in `GraphSymbolSearchTests.cs`
- [x] All 60 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)