### PR TITLE
Fix: Auto-refresh graph when symbol not found but exists in codebase

### DIFF
--- a/RoslynMcpServer.Graph/GraphDatabase.Files.cs
+++ b/RoslynMcpServer.Graph/GraphDatabase.Files.cs
@@ -145,6 +145,86 @@ public sealed partial class GraphDatabase
     }
 
     /// <summary>
+    /// Checks if a file has any symbols in the graph.
+    /// Issue: #35
+    /// </summary>
+    public async Task<bool> IsFileInGraphAsync(long solutionId, string filePath)
+    {
+        if (_connection == null) throw new InvalidOperationException("Database not open");
+
+        var count = await _connection.ExecuteScalarAsync<int>(
+            "SELECT COUNT(*) FROM Symbols WHERE SolutionId = @SolutionId AND FilePath = @FilePath",
+            new { SolutionId = solutionId, FilePath = filePath });
+
+        return count > 0;
+    }
+
+    /// <summary>
+    /// Updates the content hash for a file. Used for testing.
+    /// Issue: #35
+    /// </summary>
+    public async Task UpdateFileHashAsync(long solutionId, string filePath, string contentHash)
+    {
+        if (_connection == null) throw new InvalidOperationException("Database not open");
+
+        var existing = await GetFileAsync(solutionId, filePath);
+        if (existing == null)
+        {
+            await _connection.ExecuteAsync(
+                """
+                INSERT INTO Files (SolutionId, FilePath, LastModified, ContentHash, LastAnalyzed)
+                VALUES (@SolutionId, @FilePath, @LastModified, @ContentHash, @LastAnalyzed)
+                """,
+                new
+                {
+                    SolutionId = solutionId,
+                    FilePath = filePath,
+                    LastModified = DateTime.UtcNow.ToString("o"),
+                    ContentHash = contentHash,
+                    LastAnalyzed = DateTime.UtcNow.ToString("o")
+                });
+        }
+        else
+        {
+            await _connection.ExecuteAsync(
+                "UPDATE Files SET ContentHash = @ContentHash WHERE SolutionId = @SolutionId AND FilePath = @FilePath",
+                new { SolutionId = solutionId, FilePath = filePath, ContentHash = contentHash });
+        }
+    }
+
+    /// <summary>
+    /// Gets files that need analysis: either not in graph or stale (hash mismatch).
+    /// Issue: #35
+    /// </summary>
+    public async Task<IReadOnlyList<string>> GetFilesNeedingAnalysisAsync(
+        long solutionId, IDictionary<string, string> currentFileHashes)
+    {
+        if (_connection == null) throw new InvalidOperationException("Database not open");
+
+        var needsAnalysis = new List<string>();
+
+        foreach (var (filePath, currentHash) in currentFileHashes)
+        {
+            // Check if file is tracked
+            var tracked = await GetFileAsync(solutionId, filePath);
+            if (tracked == null)
+            {
+                // File not in graph - needs analysis
+                needsAnalysis.Add(filePath);
+                continue;
+            }
+
+            // Check if hash changed (stale)
+            if (tracked.ContentHash != currentHash)
+            {
+                needsAnalysis.Add(filePath);
+            }
+        }
+
+        return needsAnalysis;
+    }
+
+    /// <summary>
     /// Computes SHA256 hash of file content (first 16 hex chars).
     /// </summary>
     public static string ComputeFileHash(string filePath)

--- a/RoslynMcpServer.Tests/Graph/GraphAutoRefreshTests.cs
+++ b/RoslynMcpServer.Tests/Graph/GraphAutoRefreshTests.cs
@@ -1,0 +1,154 @@
+using RoslynMcpServer.Graph;
+
+namespace RoslynMcpServer.Tests.Graph;
+
+/// <summary>
+/// Tests for automatic graph refresh when symbols are not found.
+/// Issue: #35
+/// </summary>
+public class GraphAutoRefreshTests : IAsyncLifetime
+{
+    private GraphDatabase _db = null!;
+    private SolutionRecord _solution = null!;
+
+    public async Task InitializeAsync()
+    {
+        _db = GraphDatabase.CreateInMemory();
+        await _db.OpenAsync();
+        _solution = await _db.GetOrCreateSolutionAsync(@"C:\test\MySolution.sln");
+    }
+
+    public Task DisposeAsync()
+    {
+        _db.Dispose();
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Tests that a file not in the graph is detected as needing analysis.
+    /// Issue: #35
+    /// </summary>
+    [Fact]
+    public async Task IsFileInGraphAsync_FileNotTracked_ReturnsFalse()
+    {
+        // Arrange - file not added to graph
+        var filePath = @"C:\test\NewFile.cs";
+
+        // Act
+        var isInGraph = await _db.IsFileInGraphAsync(_solution.Id, filePath);
+
+        // Assert
+        Assert.False(isInGraph);
+    }
+
+    /// <summary>
+    /// Tests that a file with symbols is detected as being in the graph.
+    /// Issue: #35
+    /// </summary>
+    [Fact]
+    public async Task IsFileInGraphAsync_FileWithSymbols_ReturnsTrue()
+    {
+        // Arrange - add a symbol from a file
+        var filePath = @"C:\test\ExistingFile.cs";
+        await _db.InsertSymbolAsync(new SymbolRecord
+        {
+            SolutionId = _solution.Id,
+            Kind = SymbolKind.Method,
+            Name = "ExistingMethod",
+            QualifiedName = "Test.ExistingMethod()",
+            FilePath = filePath,
+            Line = 10
+        });
+
+        // Act
+        var isInGraph = await _db.IsFileInGraphAsync(_solution.Id, filePath);
+
+        // Assert
+        Assert.True(isInGraph);
+    }
+
+    /// <summary>
+    /// Tests getting all files that need analysis (not in graph or stale).
+    /// Issue: #35
+    /// </summary>
+    [Fact]
+    public async Task GetFilesNeedingAnalysisAsync_MixedFiles_ReturnsCorrectList()
+    {
+        // Arrange
+        var existingFile = @"C:\test\Existing.cs";
+        var staleFile = @"C:\test\Stale.cs";
+        var newFile = @"C:\test\New.cs";
+
+        // Add existing file with current hash
+        await _db.InsertSymbolAsync(new SymbolRecord
+        {
+            SolutionId = _solution.Id,
+            Kind = SymbolKind.Method,
+            Name = "Method1",
+            QualifiedName = "Test.Method1()",
+            FilePath = existingFile,
+            Line = 10
+        });
+        await _db.UpdateFileHashAsync(_solution.Id, existingFile, "hash1");
+
+        // Add stale file with old hash
+        await _db.InsertSymbolAsync(new SymbolRecord
+        {
+            SolutionId = _solution.Id,
+            Kind = SymbolKind.Method,
+            Name = "Method2",
+            QualifiedName = "Test.Method2()",
+            FilePath = staleFile,
+            Line = 10
+        });
+        await _db.UpdateFileHashAsync(_solution.Id, staleFile, "old_hash");
+
+        // Provide current hashes (staleFile has different hash now)
+        var currentHashes = new Dictionary<string, string>
+        {
+            { existingFile, "hash1" },      // Same - not stale
+            { staleFile, "new_hash" },      // Different - stale
+            { newFile, "hash3" }            // New file - not in graph
+        };
+
+        // Act
+        var needsAnalysis = await _db.GetFilesNeedingAnalysisAsync(_solution.Id, currentHashes);
+
+        // Assert
+        Assert.Equal(2, needsAnalysis.Count);
+        Assert.Contains(staleFile, needsAnalysis);
+        Assert.Contains(newFile, needsAnalysis);
+        Assert.DoesNotContain(existingFile, needsAnalysis);
+    }
+
+    /// <summary>
+    /// Tests that FindSymbolWithRefreshAsync finds a symbol after refresh hint.
+    /// This tests the database-level support for the refresh workflow.
+    /// Issue: #35
+    /// </summary>
+    [Fact]
+    public async Task FindSymbolAsync_AfterInsert_FindsNewSymbol()
+    {
+        // Arrange - empty graph initially
+        var result1 = await _db.FindSymbolAsync(_solution.Id, "NewMethod");
+        Assert.Null(result1.Symbol);
+        Assert.Contains("not found", result1.Error!.ToLower());
+
+        // Act - simulate refresh by inserting the symbol
+        await _db.InsertSymbolAsync(new SymbolRecord
+        {
+            SolutionId = _solution.Id,
+            Kind = SymbolKind.Method,
+            Name = "NewMethod",
+            QualifiedName = "Test.Class.NewMethod()",
+            FilePath = @"C:\test\File.cs",
+            Line = 10
+        });
+
+        var result2 = await _db.FindSymbolAsync(_solution.Id, "NewMethod");
+
+        // Assert - now found
+        Assert.NotNull(result2.Symbol);
+        Assert.Equal("NewMethod", result2.Symbol.Name);
+    }
+}

--- a/src/RoslynTools.Graph.cs
+++ b/src/RoslynTools.Graph.cs
@@ -315,6 +315,20 @@ public static partial class RoslynTools
 
         // Use FindSymbolAsync for partial name matching (Issue #33)
         var searchResult = await db.FindSymbolAsync(solution.Id, symbolName);
+
+        // Issue #35: If not found, try Roslyn search and analyze stale files
+        if (searchResult.Symbol == null && _analyzerService != null)
+        {
+            var autoRefreshedFiles = await TryRefreshFilesForSymbolAsync(
+                db, solution.Id, solutionPath, symbolName);
+
+            if (autoRefreshedFiles.Count > 0)
+            {
+                // Retry graph search after refresh
+                searchResult = await db.FindSymbolAsync(solution.Id, symbolName);
+            }
+        }
+
         if (searchResult.Symbol == null)
         {
             var error = searchResult.Error ?? $"Symbol '{symbolName}' not found in graph.";
@@ -455,6 +469,83 @@ public static partial class RoslynTools
             content = new[] { new { type = "text", text = message } },
             isError = true
         };
+    }
+
+    /// <summary>
+    /// Tries to find a symbol via Roslyn and refresh stale files containing it.
+    /// Issue: #35
+    /// </summary>
+    private static async Task<List<string>> TryRefreshFilesForSymbolAsync(
+        GraphDatabase db, long solutionId, string solutionPath, string symbolName)
+    {
+        var refreshedFiles = new List<string>();
+
+        if (_analyzerService == null) return refreshedFiles;
+
+        try
+        {
+            // Search for symbol using Roslyn
+            var roslynResult = await _analyzerService.SearchSymbolsAsync(
+                solutionPath,
+                symbolName,
+                SymbolKindFilter.TypeAndMember,
+                MatchType.Contains,
+                maxResults: 10,
+                compact: true);
+
+            if (!roslynResult.Success || roslynResult.Symbols == null || roslynResult.Symbols.Count == 0)
+            {
+                return refreshedFiles;
+            }
+
+            // Get unique file paths from Roslyn results
+            var filePaths = roslynResult.Symbols
+                .Where(s => !string.IsNullOrEmpty(s.FilePath))
+                .Select(s => s.FilePath!)
+                .Distinct()
+                .ToList();
+
+            if (filePaths.Count == 0) return refreshedFiles;
+
+            // Compute current hashes for found files
+            var currentHashes = new Dictionary<string, string>();
+            foreach (var filePath in filePaths)
+            {
+                if (File.Exists(filePath))
+                {
+                    currentHashes[filePath] = GraphDatabase.ComputeFileHash(filePath);
+                }
+            }
+
+            // Check which files need analysis
+            var needsAnalysis = await db.GetFilesNeedingAnalysisAsync(solutionId, currentHashes);
+
+            if (needsAnalysis.Count == 0) return refreshedFiles;
+
+            // Load solution and analyze needed files
+            var roslynSolution = await _analyzerService.LoadSolutionAsync(solutionPath);
+            if (roslynSolution == null) return refreshedFiles;
+
+            var analyzer = new GraphAnalyzer(db);
+            foreach (var filePath in needsAnalysis)
+            {
+                var document = roslynSolution.Projects
+                    .SelectMany(p => p.Documents)
+                    .FirstOrDefault(d => d.FilePath == filePath);
+
+                if (document != null)
+                {
+                    await analyzer.AnalyzeDocumentAsync(document, solutionId);
+                    refreshedFiles.Add(Path.GetFileName(filePath));
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine($"Error refreshing files for symbol '{symbolName}': {ex.Message}");
+        }
+
+        return refreshedFiles;
     }
 }
 

--- a/src/RoslynTools.GraphImpact.cs
+++ b/src/RoslynTools.GraphImpact.cs
@@ -167,6 +167,20 @@ public static partial class RoslynTools
 
         // Use FindSymbolAsync for partial name matching (Issue #33)
         var searchResult = await db.FindSymbolAsync(solution.Id, symbolName);
+
+        // Issue #35: If not found, try Roslyn search and analyze stale files
+        if (searchResult.Symbol == null && _analyzerService != null)
+        {
+            var refreshedFiles = await TryRefreshFilesForSymbolAsync(
+                db, solution.Id, solutionPath, symbolName);
+
+            if (refreshedFiles.Count > 0)
+            {
+                // Retry graph search after refresh
+                searchResult = await db.FindSymbolAsync(solution.Id, symbolName);
+            }
+        }
+
         if (searchResult.Symbol == null)
         {
             var error = searchResult.Error ?? $"Symbol '{symbolName}' not found in graph.";


### PR DESCRIPTION
## Summary
- When a symbol is not found in the graph, now uses Roslyn to search for it in the codebase
- If found via Roslyn, checks if the file needs analysis (new or stale)
- Automatically analyzes needed files and retries the graph search
- Added `IsFileInGraphAsync`, `UpdateFileHashAsync`, `GetFilesNeedingAnalysisAsync` methods to GraphDatabase

Fixes #35

## Test plan
- [x] Added 4 new tests in `GraphAutoRefreshTests.cs`
- [x] All 64 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)