### PR TITLE
Fix: Reduce false positives in dead code detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,9 +49,14 @@ Use Roslyn MCP tools for C# files:
 | Add new member | `roslyn_add_member` |
 | Find references | `roslyn_get_references` |
 | Find callers | `roslyn_get_callers` |
+| Find callers (cached) | `roslyn_query_graph` (auto-refreshes stale files) |
+| Impact analysis | `roslyn_graph_impact` (auto-refreshes stale files) |
+| Find dead code | `roslyn_find_dead_code` (may have false positives*) |
 | Check errors | `roslyn_get_diagnostics` |
 | Fix warnings | `roslyn_apply_code_fix` or `roslyn_batch_apply_code_fixes` |
 | Rename symbol | `roslyn_rename_symbol` |
+
+*Dead code detection may flag DTO properties used via JSON serialization (reflection-based).
 
 **For full tool reference:** Call `roslyn_get_instructions` with topic "tools"
 

--- a/CLAUDE_TEMPLATE.md
+++ b/CLAUDE_TEMPLATE.md
@@ -44,14 +44,16 @@ Use Roslyn MCP tools for C# files:
 | Add new member | `roslyn_add_member` |
 | Find references | `roslyn_get_references` |
 | Find callers | `roslyn_get_callers` |
-| Find callers (cached) | `roslyn_query_graph` |
-| Impact analysis | `roslyn_graph_impact` |
-| Find dead code | `roslyn_find_dead_code` |
+| Find callers (cached) | `roslyn_query_graph` (auto-refreshes stale files) |
+| Impact analysis | `roslyn_graph_impact` (auto-refreshes stale files) |
+| Find dead code | `roslyn_find_dead_code` (may have false positives*) |
 | Check errors | `roslyn_get_diagnostics` |
 | Fix warnings | `roslyn_apply_code_fix` |
 | Rename symbol | `roslyn_rename_symbol` |
 
 **For full tool reference:** Call `roslyn_get_instructions` with topic "tools"
+
+*Dead code detection may flag DTO properties used via JSON serialization (reflection-based). Properties with attributes are automatically excluded.
 
 ## Project Structure
 

--- a/Instructions/Topics/tools.md
+++ b/Instructions/Topics/tools.md
@@ -39,9 +39,11 @@ You have access to Roslyn MCP tools for C# code analysis. These tools provide se
 |------|---------|
 | `roslyn_graph_status` | Check if call graph exists for solution |
 | `roslyn_graph_analyze` | Build/update call graph database |
-| `roslyn_query_graph` | Query callers/callees with recursive depth |
-| `roslyn_graph_impact` | Analyze blast radius if a symbol changes |
-| `roslyn_find_dead_code` | Find methods/properties with no callers |
+| `roslyn_query_graph` | Query callers/callees with recursive depth (auto-refreshes stale files) |
+| `roslyn_graph_impact` | Analyze blast radius if a symbol changes (auto-refreshes stale files) |
+| `roslyn_find_dead_code` | Find methods/properties with no callers (may have false positives*) |
+
+*Dead code detection limitations: DTO properties used via JSON serialization (reflection-based) may be flagged as dead code since the call graph cannot track reflection. Properties with attributes are automatically excluded.
 
 ### Solution & Project
 
@@ -111,7 +113,11 @@ Use native tools (Read, Edit, Grep, Glob) only for:
 ### Finding dead code
 1. `roslyn_graph_analyze(solutionPath)` → build call graph
 2. `roslyn_find_dead_code(solutionPath)` → find unused methods/properties
-3. Review results - excludes entry points like Main, event handlers, interface implementations
+3. Review results - excludes:
+   - Entry points (Main, RunAsync, event handlers)
+   - Properties with attributes (likely serialization)
+   - External/BCL symbols
+4. **Note**: May produce false positives for DTO properties used via JSON serialization (reflection-based access not tracked)
 
 ### Fixing compiler warnings
 1. `roslyn_get_diagnostics(severityFilter: "warning")` → see all warnings

--- a/README.md
+++ b/README.md
@@ -146,9 +146,23 @@ The CLAUDE.md file is instructions **for Claude to read**, not commands for you 
 | `roslyn_get_projects_in_build_order` | Get solution structure and dependencies |
 | `roslyn_graph_status` | Check if a call graph database exists for a solution |
 | `roslyn_graph_analyze` | Build or update the call graph database |
-| `roslyn_query_graph` | Query callers/callees with recursive depth from the graph |
-| `roslyn_graph_impact` | Analyze blast radius - what breaks if you change a symbol |
-| `roslyn_find_dead_code` | Find methods and properties with no callers |
+| `roslyn_query_graph` | Query callers/callees with recursive depth (auto-refreshes stale files) |
+| `roslyn_graph_impact` | Analyze blast radius - what breaks if you change a symbol (auto-refreshes) |
+| `roslyn_find_dead_code` | Find methods/properties with no callers (see limitations below) |
+
+### Dead Code Detection Limitations
+
+`roslyn_find_dead_code` uses static analysis and may produce **false positives** for:
+- **DTO properties** used via JSON serialization (reflection-based access cannot be tracked)
+- **Properties without attributes** in model classes
+
+The tool automatically excludes:
+- Entry points (`Main`, `RunAsync`, event handlers)
+- Properties with any attributes (likely used for serialization)
+- External/BCL symbols
+- Test files (optional)
+
+Review results carefully - some flagged code may be used via reflection.
 
 ## Usage Examples
 

--- a/RoslynMcpServer.Tests/Graph/GraphImpactTests.cs
+++ b/RoslynMcpServer.Tests/Graph/GraphImpactTests.cs
@@ -291,4 +291,89 @@ public class DeadCodeDetectionTests : IAsyncLifetime
         // Assert
         Assert.Empty(callers);
     }
+
+    /// <summary>
+    /// Tests that external symbols (BCL, framework) are filtered out.
+    /// Issue: #36
+    /// </summary>
+    [Fact]
+    public async Task GetSymbolsAsync_ExternalSymbols_FilteredByFilePath()
+    {
+        // Arrange - create local and external symbols
+        await CreateSymbolAsync("LocalMethod", SymbolKind.Method, @"C:\test\Service.cs");
+        await CreateSymbolAsync("ExternalMethod", SymbolKind.Method, "external");
+
+        // Act - get all symbols
+        var allSymbols = await _db.GetSymbolsAsync(_solution.Id, kind: SymbolKind.Method);
+
+        // Filter like FindDeadCodeAsync does
+        var localSymbols = allSymbols
+            .Where(s => !string.IsNullOrEmpty(s.FilePath) && s.FilePath != "external")
+            .ToList();
+
+        // Assert - external symbols filtered out
+        Assert.Single(localSymbols);
+        Assert.Equal("LocalMethod", localSymbols[0].Name);
+    }
+
+    /// <summary>
+    /// Tests that properties accessed via Reads edge are not flagged as dead.
+    /// Issue: #36 - Properties use Reads/Accesses edges, not Calls.
+    /// </summary>
+    [Fact]
+    public async Task GetCallersAsync_PropertyWithReadsEdge_ReturnsCallers()
+    {
+        // Arrange - create property and reader
+        var reader = await CreateSymbolAsync("ReaderMethod", SymbolKind.Method);
+        var property = await CreateSymbolAsync("MyProperty", SymbolKind.Property);
+
+        // Property is read, not called
+        await _db.InsertEdgeAsync(reader.Id, property.Id, EdgeType.Reads);
+
+        // Act - check callers with null edgeType (all edges)
+        var callers = await _db.GetCallersAsync(property.Id, edgeType: null);
+
+        // Assert - should find the reader
+        Assert.Single(callers);
+        Assert.Equal("ReaderMethod", callers[0].Name);
+    }
+
+    /// <summary>
+    /// Tests that properties accessed via Accesses edge are not flagged as dead.
+    /// Issue: #36
+    /// </summary>
+    [Fact]
+    public async Task GetCallersAsync_PropertyWithAccessesEdge_ReturnsCallers()
+    {
+        // Arrange
+        var accessor = await CreateSymbolAsync("AccessorMethod", SymbolKind.Method);
+        var property = await CreateSymbolAsync("MyProperty", SymbolKind.Property);
+
+        await _db.InsertEdgeAsync(accessor.Id, property.Id, EdgeType.Accesses);
+
+        // Act - check callers with null edgeType
+        var callers = await _db.GetCallersAsync(property.Id, edgeType: null);
+
+        // Assert
+        Assert.Single(callers);
+    }
+
+    /// <summary>
+    /// Tests that Calls-only check misses property reads.
+    /// Issue: #36 - This was the original bug.
+    /// </summary>
+    [Fact]
+    public async Task GetCallersAsync_PropertyWithReadsEdge_CallsOnlyMissesIt()
+    {
+        // Arrange
+        var reader = await CreateSymbolAsync("ReaderMethod", SymbolKind.Method);
+        var property = await CreateSymbolAsync("MyProperty", SymbolKind.Property);
+        await _db.InsertEdgeAsync(reader.Id, property.Id, EdgeType.Reads);
+
+        // Act - check with Calls edge type only (old behavior)
+        var callersCallsOnly = await _db.GetCallersAsync(property.Id, edgeType: EdgeType.Calls);
+
+        // Assert - Calls-only misses the read
+        Assert.Empty(callersCallsOnly);
+    }
 }

--- a/src/RoslynTools.GraphImpact.cs
+++ b/src/RoslynTools.GraphImpact.cs
@@ -269,9 +269,11 @@ public static partial class RoslynTools
         }
 
         // Get all symbols that are methods or properties
+        // Issue #36: Filter out external symbols (BCL, framework types)
         var allSymbols = await db.GetSymbolsAsync(solution.Id, null, null);
         var candidateSymbols = allSymbols
             .Where(s => s.Kind is SymbolKind.Method or SymbolKind.Property)
+            .Where(s => !string.IsNullOrEmpty(s.FilePath) && s.FilePath != "external")
             .Where(s => !IsEntryPoint(s))
             .Where(s => includePrivate || !IsPrivateSymbol(s))
             .Where(s => includeTests || !IsTestFile(s.FilePath))
@@ -279,13 +281,31 @@ public static partial class RoslynTools
 
         var deadCode = new List<DeadCodeEntry>();
 
+        // Issue #36: Load Roslyn solution to check for attributes
+        Microsoft.CodeAnalysis.Solution? roslynSolution = null;
+        if (_analyzerService != null)
+        {
+            roslynSolution = await _analyzerService.LoadSolutionAsync(solutionPath);
+        }
+
         foreach (var symbol in candidateSymbols)
         {
             if (deadCode.Count >= maxResults) break;
 
-            var callers = await db.GetCallersAsync(symbol.Id, EdgeType.Calls);
+            // Issue #36: For properties, check Reads/Accesses edges too, not just Calls
+            // Use null edgeType to check ALL edge types
+            var callers = await db.GetCallersAsync(symbol.Id, edgeType: null);
             if (callers.Count == 0)
             {
+                // Issue #36: Skip properties with any attributes (likely used for serialization)
+                if (symbol.Kind == SymbolKind.Property && roslynSolution != null)
+                {
+                    if (await HasAttributesAsync(roslynSolution, symbol.FilePath, symbol.Line))
+                    {
+                        continue;
+                    }
+                }
+
                 deadCode.Add(new DeadCodeEntry
                 {
                     Name = symbol.Name,
@@ -337,6 +357,7 @@ public static partial class RoslynTools
 
         // Common entry points that shouldn't be flagged as dead code
         return name == "Main" ||
+               name == "RunAsync" || // Issue #36: Common entry point pattern
                name.StartsWith("On") || // Event handlers: OnClick, OnLoad, etc.
                name.EndsWith("Async") && name.StartsWith("On") ||
                qualifiedName.Contains(".Program.") ||
@@ -355,6 +376,46 @@ public static partial class RoslynTools
         // and symbol name starts with underscore or lowercase, likely private
         return symbol.Name.StartsWith("_") ||
                (symbol.Name.Length > 0 && char.IsLower(symbol.Name[0]));
+    }
+
+    /// <summary>
+    /// Checks if a symbol at the given file/line has any attributes.
+    /// Issue: #36 - Properties with attributes are likely used for serialization.
+    /// </summary>
+    private static async Task<bool> HasAttributesAsync(
+        Microsoft.CodeAnalysis.Solution solution, string filePath, int line)
+    {
+        try
+        {
+            var document = solution.Projects
+                .SelectMany(p => p.Documents)
+                .FirstOrDefault(d => d.FilePath == filePath);
+
+            if (document == null) return false;
+
+            var syntaxRoot = await document.GetSyntaxRootAsync();
+            if (syntaxRoot == null) return false;
+
+            // Find the node at the given line (0-based in Roslyn)
+            var lineSpan = syntaxRoot.SyntaxTree.GetText().Lines[line - 1];
+            var node = syntaxRoot.FindNode(lineSpan.Span);
+
+            // Walk up to find a property declaration
+            while (node != null)
+            {
+                if (node is Microsoft.CodeAnalysis.CSharp.Syntax.PropertyDeclarationSyntax propDecl)
+                {
+                    return propDecl.AttributeLists.Count > 0;
+                }
+                node = node.Parent;
+            }
+
+            return false;
+        }
+        catch
+        {
+            return false; // If we can't check, assume no attributes
+        }
     }
 
     private static object CreateToolResponse(object result, bool isError = false)


### PR DESCRIPTION
## Summary
- Filter out external symbols (BCL/framework types with `FilePath == "external"`)
- Check ALL edge types (Reads/Accesses/Writes) for property callers, not just Calls
- Exclude properties with any attributes (likely used for serialization)
- Add `RunAsync` to entry point exclusions
- Add 4 unit tests for edge type handling
- Update documentation (README, CLAUDE.md, templates, tools.md) with false positive notes

## Test plan
- [x] All 68 unit tests pass
- [x] No build errors (roslyn_get_diagnostics)
- [x] Real-world test: `roslyn_find_dead_code` no longer flags DTO properties or BCL types

Fixes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)