### PR TITLE
Feature: Add roslyn_delete_member tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,17 @@ Use this path for all `roslyn_*` tool calls.
 
 **Check before PR:** Are all relevant docs updated?
 
+## MANDATORY: Real-World Testing for Tools
+
+**When adding NEW tools or MODIFYING existing tools:**
+
+1. Unit tests passing is NOT sufficient
+2. **DO NOT push/merge** until real-world testing is complete
+3. Work with code owner to test on actual solutions
+4. Only after code owner confirms it works → push, PR, merge
+
+This ensures tools work correctly in production scenarios, not just unit test mocks.
+
 ## Tool Preferences
 
 Use Roslyn MCP tools for C# files:
@@ -47,6 +58,7 @@ Use Roslyn MCP tools for C# files:
 | Read a method | `roslyn_get_method_body` |
 | Edit a method | `roslyn_update_method` |
 | Add new member | `roslyn_add_member` |
+| Delete member | `roslyn_delete_member` |
 | Find references | `roslyn_get_references` |
 | Find callers | `roslyn_get_callers` |
 | Find callers (cached) | `roslyn_query_graph` (auto-refreshes stale files) |

--- a/CLAUDE_TEMPLATE.md
+++ b/CLAUDE_TEMPLATE.md
@@ -42,6 +42,7 @@ Use Roslyn MCP tools for C# files:
 | Read a method | `roslyn_get_method_body` |
 | Edit a method | `roslyn_update_method` |
 | Add new member | `roslyn_add_member` |
+| Delete member | `roslyn_delete_member` |
 | Find references | `roslyn_get_references` |
 | Find callers | `roslyn_get_callers` |
 | Find callers (cached) | `roslyn_query_graph` (auto-refreshes stale files) |

--- a/Instructions/Topics/tools.md
+++ b/Instructions/Topics/tools.md
@@ -23,6 +23,7 @@ You have access to Roslyn MCP tools for C# code analysis. These tools provide se
 |------|---------|
 | `roslyn_update_method` | Replace a method's implementation |
 | `roslyn_add_member` | Add new method/property/field to a type |
+| `roslyn_delete_member` | Delete a method/property/field from a type |
 | `roslyn_rename_symbol` | Rename across entire solution |
 
 ### Diagnostics & Fixes
@@ -69,6 +70,7 @@ You have access to Roslyn MCP tools for C# code analysis. These tools provide se
 | Read a method | `roslyn_get_method_body` | Read requires knowing line numbers |
 | Edit a method | `roslyn_update_method` | Edit can break code with text patterns |
 | Add new member | `roslyn_add_member` | Edit doesn't format or place correctly |
+| Delete member | `roslyn_delete_member` | Edit may miss attributes, XML docs, trivia |
 | Find usages | `roslyn_get_references` | Grep finds text matches, not usages |
 | Find callers | `roslyn_get_callers` | References includes non-calls |
 | Find callers (large codebase) | `roslyn_query_graph` | Faster with cached graph |
@@ -118,6 +120,12 @@ Use native tools (Read, Edit, Grep, Glob) only for:
    - Properties with attributes (likely serialization)
    - External/BCL symbols
 4. **Note**: May produce false positives for DTO properties used via JSON serialization (reflection-based access not tracked)
+
+### Cleaning up dead code
+1. `roslyn_find_dead_code(solutionPath)` → identify unused members
+2. Review each result to confirm it's truly dead (not reflection-based)
+3. `roslyn_delete_member(typeName, memberName)` → remove confirmed dead code
+4. Includes attributes and XML docs in deletion
 
 ### Fixing compiler warnings
 1. `roslyn_get_diagnostics(severityFilter: "warning")` → see all warnings

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ The CLAUDE.md file is instructions **for Claude to read**, not commands for you 
 | `roslyn_get_method_body` | Get the full source code of a specific method |
 | `roslyn_update_method` | Replace a method's implementation |
 | `roslyn_add_member` | Add a new method/property/field to a type |
+| `roslyn_delete_member` | Delete a method/property/field from a type (includes attributes, XML docs) |
 | `roslyn_get_diagnostics` | Compile and get warnings/errors (CS* and CA* rules) |
 | `roslyn_apply_code_fix` | Apply Roslyn's suggested fix for a single diagnostic |
 | `roslyn_batch_apply_code_fixes` | Batch apply fixes for all diagnostics of a specific type |

--- a/RoslynMcpServer.Tests/Services/DeleteMemberTests.cs
+++ b/RoslynMcpServer.Tests/Services/DeleteMemberTests.cs
@@ -1,0 +1,232 @@
+namespace RoslynMcpServer.Tests.Services;
+
+/// <summary>
+/// Tests for the roslyn_delete_member tool.
+/// Issue: #39
+/// </summary>
+public class DeleteMemberTests : IAsyncLifetime
+{
+    private string _tempDir = "";
+    private string _solutionPath = "";
+    private string _projectPath = "";
+    private string _sourceFilePath = "";
+    private SolutionAnalyzerService _service = null!;
+
+    public async Task InitializeAsync()
+    {
+        _service = new SolutionAnalyzerService();
+
+        // Create a temporary solution with a test class
+        _tempDir = Path.Combine(Path.GetTempPath(), $"DeleteMemberTest_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+
+        _solutionPath = Path.Combine(_tempDir, "Test.sln");
+        _projectPath = Path.Combine(_tempDir, "Test.csproj");
+        _sourceFilePath = Path.Combine(_tempDir, "TestClass.cs");
+
+        // Create solution file
+        await File.WriteAllTextAsync(_solutionPath, """
+            Microsoft Visual Studio Solution File, Format Version 12.00
+            Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test", "Test.csproj", "{12345678-1234-1234-1234-123456789012}"
+            EndProject
+            """);
+
+        // Create project file
+        await File.WriteAllTextAsync(_projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+
+        // Create source file with various members
+        await File.WriteAllTextAsync(_sourceFilePath, """
+            namespace Test;
+
+            /// <summary>
+            /// Test class with various members.
+            /// </summary>
+            public class TestClass
+            {
+                private readonly string _field1;
+                private int _field2;
+
+                /// <summary>
+                /// A property to delete.
+                /// </summary>
+                [Obsolete]
+                public string PropertyToDelete { get; set; } = "";
+
+                public string KeepProperty { get; set; } = "";
+
+                /// <summary>
+                /// A method to delete.
+                /// </summary>
+                public void MethodToDelete()
+                {
+                    Console.WriteLine("Delete me");
+                }
+
+                public void KeepMethod()
+                {
+                    Console.WriteLine("Keep me");
+                }
+
+                /// <summary>
+                /// Overloaded method - first overload.
+                /// </summary>
+                public void OverloadedMethod(string value)
+                {
+                    Console.WriteLine(value);
+                }
+
+                /// <summary>
+                /// Overloaded method - second overload.
+                /// </summary>
+                public void OverloadedMethod(int value)
+                {
+                    Console.WriteLine(value);
+                }
+            }
+            """);
+
+        await Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        // Cleanup temp directory
+        if (Directory.Exists(_tempDir))
+        {
+            try { Directory.Delete(_tempDir, true); }
+            catch { /* Ignore cleanup errors */ }
+        }
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Tests deleting a method by name.
+    /// </summary>
+    [Fact]
+    public async Task DeleteMemberAsync_DeleteMethod_RemovesMethod()
+    {
+        // Act
+        var result = await _service.DeleteMemberAsync(
+            _solutionPath,
+            "TestClass",
+            "MethodToDelete");
+
+        // Assert
+        Assert.True(result.Success, result.Error);
+        Assert.Equal("Method", result.MemberKind);
+        Assert.Equal("MethodToDelete", result.MemberName);
+
+        // Verify the method is gone
+        var content = await File.ReadAllTextAsync(_sourceFilePath);
+        Assert.DoesNotContain("MethodToDelete", content);
+        Assert.Contains("KeepMethod", content);
+    }
+
+    /// <summary>
+    /// Tests deleting a property by name.
+    /// </summary>
+    [Fact]
+    public async Task DeleteMemberAsync_DeleteProperty_RemovesPropertyAndAttributes()
+    {
+        // Act
+        var result = await _service.DeleteMemberAsync(
+            _solutionPath,
+            "TestClass",
+            "PropertyToDelete");
+
+        // Assert
+        Assert.True(result.Success, result.Error);
+        Assert.Equal("Property", result.MemberKind);
+
+        // Verify the property and its attribute are gone
+        var content = await File.ReadAllTextAsync(_sourceFilePath);
+        Assert.DoesNotContain("PropertyToDelete", content);
+        Assert.DoesNotContain("[Obsolete]", content);
+        Assert.Contains("KeepProperty", content);
+    }
+
+    /// <summary>
+    /// Tests deleting a field by name.
+    /// </summary>
+    [Fact]
+    public async Task DeleteMemberAsync_DeleteField_RemovesField()
+    {
+        // Act
+        var result = await _service.DeleteMemberAsync(
+            _solutionPath,
+            "TestClass",
+            "_field2");
+
+        // Assert
+        Assert.True(result.Success, result.Error);
+        Assert.Equal("Field", result.MemberKind);
+
+        // Verify the field is gone
+        var content = await File.ReadAllTextAsync(_sourceFilePath);
+        Assert.DoesNotContain("_field2", content);
+        Assert.Contains("_field1", content);
+    }
+
+    /// <summary>
+    /// Tests deleting a method overload using parameterTypes.
+    /// </summary>
+    [Fact]
+    public async Task DeleteMemberAsync_DeleteMethodOverload_RemovesCorrectOverload()
+    {
+        // Act - delete the int overload
+        var result = await _service.DeleteMemberAsync(
+            _solutionPath,
+            "TestClass",
+            "OverloadedMethod",
+            parameterTypes: "int");
+
+        // Assert
+        Assert.True(result.Success, result.Error);
+
+        // Verify only the int overload is gone
+        var content = await File.ReadAllTextAsync(_sourceFilePath);
+        Assert.Contains("OverloadedMethod(string value)", content);
+        Assert.DoesNotContain("OverloadedMethod(int value)", content);
+    }
+
+    /// <summary>
+    /// Tests that deleting non-existent member returns error.
+    /// </summary>
+    [Fact]
+    public async Task DeleteMemberAsync_MemberNotFound_ReturnsError()
+    {
+        // Act
+        var result = await _service.DeleteMemberAsync(
+            _solutionPath,
+            "TestClass",
+            "NonExistentMethod");
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Contains("not found", result.Error);
+    }
+
+    /// <summary>
+    /// Tests that deleting from non-existent type returns error.
+    /// </summary>
+    [Fact]
+    public async Task DeleteMemberAsync_TypeNotFound_ReturnsError()
+    {
+        // Act
+        var result = await _service.DeleteMemberAsync(
+            _solutionPath,
+            "NonExistentClass",
+            "SomeMethod");
+
+        // Assert
+        Assert.False(result.Success);
+        Assert.Contains("Type not found", result.Error);
+    }
+}

--- a/src/RoslynTools.DeleteMember.cs
+++ b/src/RoslynTools.DeleteMember.cs
@@ -1,0 +1,119 @@
+using System.Text.Json;
+
+namespace RoslynMcpServer;
+
+public static partial class RoslynTools
+{
+    /// <summary>
+    /// Deletes a member (method, property, field) from a type.
+    /// Issue: #39
+    /// </summary>
+    private static void RegisterDeleteMemberTool(McpServer server)
+    {
+        server.RegisterTool(
+            "roslyn_delete_member",
+            new ToolDefinition
+            {
+                Description = "Deletes a member (method, property, field) from a type. Uses Roslyn to precisely locate and remove the member including its attributes and XML documentation. Essential for cleaning up dead code identified by roslyn_find_dead_code.",
+                InputSchema = new
+                {
+                    type = "object",
+                    properties = new
+                    {
+                        solutionPath = new
+                        {
+                            type = "string",
+                            description = "Absolute path to the .sln or .slnx solution file"
+                        },
+                        typeName = new
+                        {
+                            type = "string",
+                            description = "Name of the type (class, struct, interface) containing the member"
+                        },
+                        memberName = new
+                        {
+                            type = "string",
+                            description = "Name of the member to delete"
+                        },
+                        memberKind = new
+                        {
+                            type = "string",
+                            description = "Kind of member: 'method', 'property', 'field'. Optional - used to disambiguate when multiple members have the same name.",
+                            @enum = new[] { "method", "property", "field" }
+                        },
+                        parameterTypes = new
+                        {
+                            type = "string",
+                            description = "Parameter types for method overloads, e.g. 'string, int'. Required if multiple method overloads exist."
+                        }
+                    },
+                    required = new[] { "solutionPath", "typeName", "memberName" }
+                },
+                Annotations = new ToolAnnotations
+                {
+                    ReadOnlyHint = false,
+                    IdempotentHint = false
+                }
+            },
+            async args =>
+            {
+                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var typeName = args?["typeName"]?.GetValue<string>();
+                var memberName = args?["memberName"]?.GetValue<string>();
+                var memberKind = args?["memberKind"]?.GetValue<string>();
+                var parameterTypes = args?["parameterTypes"]?.GetValue<string>();
+
+                if (string.IsNullOrWhiteSpace(solutionPath))
+                {
+                    return new
+                    {
+                        content = new[]
+                        {
+                            new { type = "text", text = "Error: solutionPath is required" }
+                        },
+                        isError = true
+                    };
+                }
+
+                if (string.IsNullOrWhiteSpace(typeName))
+                {
+                    return new
+                    {
+                        content = new[]
+                        {
+                            new { type = "text", text = "Error: typeName is required" }
+                        },
+                        isError = true
+                    };
+                }
+
+                if (string.IsNullOrWhiteSpace(memberName))
+                {
+                    return new
+                    {
+                        content = new[]
+                        {
+                            new { type = "text", text = "Error: memberName is required" }
+                        },
+                        isError = true
+                    };
+                }
+
+                var result = await _analyzerService!.DeleteMemberAsync(
+                    solutionPath,
+                    typeName,
+                    memberName,
+                    memberKind,
+                    parameterTypes);
+
+                return new
+                {
+                    content = new[]
+                    {
+                        new { type = "text", text = JsonSerializer.Serialize(result, JsonOptions) }
+                    },
+                    isError = !result.Success
+                };
+            });
+    }
+}

--- a/src/RoslynTools.cs
+++ b/src/RoslynTools.cs
@@ -35,6 +35,7 @@ public static partial class RoslynTools
         RegisterUpdateMethodTool(server);
         RegisterGetDiagnosticsTool(server);
         RegisterAddMemberTool(server);
+        RegisterDeleteMemberTool(server);
         RegisterApplyCodeFixTool(server);
         RegisterBatchApplyCodeFix(server);
         RegisterRenameSymbolTool(server);

--- a/src/SolutionAnalyzerService.DeleteMember.cs
+++ b/src/SolutionAnalyzerService.DeleteMember.cs
@@ -1,0 +1,255 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.FindSymbols;
+using Microsoft.CodeAnalysis.Formatting;
+
+namespace RoslynMcpServer;
+
+/// <summary>
+/// Delete member functionality.
+/// Issue: #39
+/// </summary>
+public partial class SolutionAnalyzerService
+{
+    /// <summary>
+    /// Deletes a member (method, property, field) from a type.
+    /// </summary>
+    public async Task<DeleteMemberResult> DeleteMemberAsync(
+        string solutionPath,
+        string typeName,
+        string memberName,
+        string? memberKind = null,
+        string? parameterTypes = null)
+    {
+        EnsureMSBuildRegistered();
+
+        if (!File.Exists(solutionPath))
+        {
+            return new DeleteMemberResult
+            {
+                Success = false,
+                Error = $"Solution file not found: {solutionPath}"
+            };
+        }
+
+        using var workspace = CreateWorkspace();
+
+        try
+        {
+            Console.Error.WriteLine($"Loading solution: {solutionPath}");
+            var solution = await workspace.OpenSolutionAsync(solutionPath);
+
+            // Find the type by name
+            var typeSymbols = await SymbolFinder.FindSourceDeclarationsAsync(
+                solution,
+                name => name.Equals(typeName, StringComparison.Ordinal) ||
+                        name.Equals(typeName, StringComparison.OrdinalIgnoreCase),
+                SymbolFilter.Type);
+
+            var targetType = typeSymbols
+                .OfType<INamedTypeSymbol>()
+                .FirstOrDefault();
+
+            if (targetType == null)
+            {
+                return new DeleteMemberResult
+                {
+                    Success = false,
+                    Error = $"Type not found: {typeName}"
+                };
+            }
+
+            // Get the syntax node for the type
+            var location = targetType.Locations.FirstOrDefault(l => l.IsInSource);
+            if (location == null)
+            {
+                return new DeleteMemberResult
+                {
+                    Success = false,
+                    Error = "Type source location not found (may be in metadata)"
+                };
+            }
+
+            var syntaxTree = location.SourceTree;
+            if (syntaxTree == null)
+            {
+                return new DeleteMemberResult
+                {
+                    Success = false,
+                    Error = "Could not get syntax tree for type"
+                };
+            }
+
+            var root = await syntaxTree.GetRootAsync();
+            var typeNode = root.FindNode(location.SourceSpan);
+
+            // Navigate up to the full type declaration
+            while (typeNode != null && typeNode is not TypeDeclarationSyntax)
+            {
+                typeNode = typeNode.Parent;
+            }
+
+            if (typeNode is not TypeDeclarationSyntax typeDeclaration)
+            {
+                return new DeleteMemberResult
+                {
+                    Success = false,
+                    Error = "Could not locate type declaration syntax node"
+                };
+            }
+
+            // Find the member to delete
+            var (memberToDelete, foundKind, signature) = FindMemberToDelete(
+                typeDeclaration, memberName, memberKind, parameterTypes);
+
+            if (memberToDelete == null)
+            {
+                var error = $"Member '{memberName}' not found in type '{typeName}'";
+                if (!string.IsNullOrEmpty(memberKind))
+                    error += $" with kind '{memberKind}'";
+                if (!string.IsNullOrEmpty(parameterTypes))
+                    error += $" with parameters '({parameterTypes})'";
+
+                return new DeleteMemberResult
+                {
+                    Success = false,
+                    Error = error
+                };
+            }
+
+            // Get the line number before deletion
+            var deletedLine = memberToDelete.GetLocation().GetLineSpan().StartLinePosition.Line + 1;
+
+            // Remove the member, including leading trivia (attributes, XML docs, blank lines)
+            var memberWithTrivia = GetMemberWithLeadingTrivia(memberToDelete, typeDeclaration);
+            var newTypeDeclaration = typeDeclaration.RemoveNode(memberWithTrivia, SyntaxRemoveOptions.KeepNoTrivia);
+
+            if (newTypeDeclaration == null)
+            {
+                return new DeleteMemberResult
+                {
+                    Success = false,
+                    Error = "Failed to remove member from type"
+                };
+            }
+
+            // Replace the type declaration in the syntax tree
+            var newRoot = root.ReplaceNode(typeDeclaration, newTypeDeclaration);
+
+            // Format the modified document
+            var formattedRoot = Formatter.Format(newRoot, workspace);
+
+            // Write the updated file
+            var filePath = syntaxTree.FilePath;
+            var newText = formattedRoot.ToFullString();
+            await File.WriteAllTextAsync(filePath, newText);
+
+            Console.Error.WriteLine($"Deleted {foundKind} '{memberName}' from {typeName} at {filePath}:{deletedLine}");
+
+            return new DeleteMemberResult
+            {
+                Success = true,
+                FilePath = filePath,
+                TypeName = targetType.ToDisplayString(),
+                MemberName = memberName,
+                MemberKind = foundKind,
+                DeletedAtLine = deletedLine,
+                Signature = signature
+            };
+        }
+        catch (Exception ex)
+        {
+            return new DeleteMemberResult
+            {
+                Success = false,
+                Error = $"Failed to delete member: {ex.Message}"
+            };
+        }
+    }
+
+    private static (MemberDeclarationSyntax? member, string kind, string signature) FindMemberToDelete(
+        TypeDeclarationSyntax typeDeclaration,
+        string memberName,
+        string? memberKind,
+        string? parameterTypes)
+    {
+        var candidates = new List<(MemberDeclarationSyntax member, string kind, string signature)>();
+
+        foreach (var member in typeDeclaration.Members)
+        {
+            var (name, kind, sig) = GetMemberInfo(member);
+
+            if (!name.Equals(memberName, StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            // Filter by kind if specified
+            if (!string.IsNullOrEmpty(memberKind))
+            {
+                var kindMatches = memberKind.ToLowerInvariant() switch
+                {
+                    "method" => member is MethodDeclarationSyntax,
+                    "property" => member is PropertyDeclarationSyntax,
+                    "field" => member is FieldDeclarationSyntax,
+                    _ => true
+                };
+
+                if (!kindMatches) continue;
+            }
+
+            // Filter by parameter types if specified (for method overloads)
+            if (!string.IsNullOrEmpty(parameterTypes) && member is MethodDeclarationSyntax method)
+            {
+                var actualParams = GetParameterTypesString(method);
+                if (!actualParams.Equals(parameterTypes.Replace(" ", ""), StringComparison.OrdinalIgnoreCase))
+                    continue;
+            }
+
+            candidates.Add((member, kind, sig));
+        }
+
+        if (candidates.Count == 0)
+            return (null, "", "");
+
+        if (candidates.Count == 1)
+            return candidates[0];
+
+        // Multiple candidates - need disambiguation
+        // Return null to force user to specify memberKind or parameterTypes
+        Console.Error.WriteLine($"Multiple members named '{memberName}' found. Specify memberKind or parameterTypes to disambiguate.");
+        return (null, "", "");
+    }
+
+    private static string GetParameterTypesString(MethodDeclarationSyntax method)
+    {
+        return string.Join(",", method.ParameterList.Parameters.Select(p =>
+        {
+            // Get the type name, simplifying generic types
+            var typeName = p.Type?.ToString() ?? "";
+            return typeName.Replace(" ", "");
+        }));
+    }
+
+    private static MemberDeclarationSyntax GetMemberWithLeadingTrivia(
+        MemberDeclarationSyntax member,
+        TypeDeclarationSyntax typeDeclaration)
+    {
+        // The member itself already includes its attributes and XML docs in the syntax node
+        // We just need to return the member as-is; Roslyn's RemoveNode handles trivia
+        return member;
+    }
+}
+
+/// <summary>
+/// Result of deleting a member.
+/// </summary>
+public class DeleteMemberResult
+{
+    public bool Success { get; init; }
+    public string? Error { get; init; }
+    public string? FilePath { get; init; }
+    public string? TypeName { get; init; }
+    public string? MemberName { get; init; }
+    public string? MemberKind { get; init; }
+    public int? DeletedAtLine { get; init; }
+    public string? Signature { get; init; }
+}


### PR DESCRIPTION
## Summary
- New `roslyn_delete_member` tool to delete methods, properties, and fields from types
- Uses Roslyn syntax tree manipulation for precise removal (includes attributes, XML docs)
- Supports disambiguation via `memberKind` and `parameterTypes` parameters
- Pairs with `roslyn_find_dead_code` for dead code cleanup workflow
- Added real-world testing requirement to CLAUDE.md

## Test plan
- [x] 6 unit tests (delete method, property, field, overload, error cases)
- [x] All 74 tests pass
- [x] Real-world test: deleted `ToDegree` from Atlas solution, verified removal, reverted

Fixes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)