### PR TITLE
Feature: Add bloom effect and meditation mode to visualization

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,10 +218,19 @@ The server includes a web-based 3D visualization of your codebase's call graph:
 
 ### Features
 - **Galaxies** = Namespaces (sphere clusters, most connected in center)
-- **Stars** = Types (white, sized by total callers)
+- **Stars** = Types (white glowing points with bloom effect)
 - **Planets** = Methods/Properties (orbiting stars, sized by callers)
+- **Meditation Mode** = Auto-follows Claude's activity (enabled by default)
 - Click to select and focus, dimming other objects
 - Controls: Left mouse = pan, Middle mouse = rotate, Scroll = zoom
+
+### Meditation Mode
+
+When Claude Code uses MCP tools like `roslyn_get_type_members` or `roslyn_get_method_body`, the visualization automatically flies to the symbol being analyzed. This creates a relaxing "meditation" experience where you can watch Claude explore your codebase in 3D.
+
+- Enabled by default when the visualization loads
+- Polls every 10 seconds for new symbol activity
+- Toggle with the "Meditation" checkbox in the UI
 
 ### Running the Visualization
 

--- a/RoslynMcpServer.Web/GraphApi.cs
+++ b/RoslynMcpServer.Web/GraphApi.cs
@@ -60,6 +60,10 @@ public static class GraphApi
         return false;
     }
 
+    private static readonly string LastSymbolFilePath = Path.Combine(
+        Path.GetTempPath(),
+        "roslyn-mcp-last-symbol.json");
+
     public static void MapGraphApi(this WebApplication app)
     {
         var api = app.MapGroup("/api");
@@ -68,6 +72,54 @@ public static class GraphApi
         api.MapGet("/projects", (Delegate)GetProjects);
         api.MapGet("/graph", (Delegate)GetGraph);
         api.MapGet("/graph/node/{id:long}", GetNode);
+        api.MapGet("/last-symbol", GetLastSymbol);
+    }
+
+    /// <summary>
+    /// Gets the last symbol processed by the MCP server (for meditation mode).
+    /// </summary>
+    private static IResult GetLastSymbol()
+    {
+        try
+        {
+            if (!File.Exists(LastSymbolFilePath))
+            {
+                return Results.Ok(new { exists = false });
+            }
+
+            var json = File.ReadAllText(LastSymbolFilePath);
+            var options = new System.Text.Json.JsonSerializerOptions
+            {
+                PropertyNameCaseInsensitive = true
+            };
+            var state = System.Text.Json.JsonSerializer.Deserialize<LastSymbolState>(json, options);
+
+            if (state == null)
+            {
+                return Results.Ok(new { exists = false });
+            }
+
+            return Results.Ok(new
+            {
+                exists = true,
+                solutionPath = state.SolutionPath,
+                qualifiedName = state.QualifiedName,
+                kind = state.Kind,
+                timestamp = state.Timestamp
+            });
+        }
+        catch
+        {
+            return Results.Ok(new { exists = false });
+        }
+    }
+
+    private class LastSymbolState
+    {
+        public string SolutionPath { get; set; } = "";
+        public string QualifiedName { get; set; } = "";
+        public string? Kind { get; set; }
+        public DateTime Timestamp { get; set; }
     }
 
     /// <summary>

--- a/RoslynMcpServer.Web/wwwroot/index.html
+++ b/RoslynMcpServer.Web/wwwroot/index.html
@@ -173,6 +173,10 @@
             <option value="">All projects</option>
         </select>
         <input type="text" id="search" placeholder="Search symbol...">
+        <label style="margin-left: 16px; display: flex; align-items: center; gap: 6px; cursor: pointer;">
+            <input type="checkbox" id="meditation-mode" style="cursor: pointer;" checked>
+            <span>Meditation</span>
+        </label>
         <div id="stats"></div>
     </div>
 
@@ -225,6 +229,7 @@
         import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
         import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
         import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+        import { OutputPass } from 'three/addons/postprocessing/OutputPass.js';
 
         const kindColors = {
             namespace: 0xffd700,  // Gold - galaxy cluster
@@ -247,7 +252,7 @@
         };
 
         let scene, camera, renderer, controls;
-        let composer, bloomPass; // Post-processing for bloom
+        let composer; // Post-processing for selective bloom
         let starsMesh, planetsMesh, highlightEdges;
         let starLights = []; // Point lights for stars
         let graphData = { nodes: [], links: [] };
@@ -269,6 +274,10 @@
         let starViewMode = false;
         let selectedStar = null;
 
+        // Meditation mode - follow MCP server activity
+        let meditationMode = true;
+        let lastSymbolTimestamp = null;
+        let meditationInterval = null;
 
         function init() {
             const container = document.getElementById('canvas-container');
@@ -279,13 +288,18 @@
             scene.background = new THREE.Color(0x000000); // Pure black space
 
             // Ambient light for overall visibility
-            const ambientLight = new THREE.AmbientLight(0x444466, 1.5);
+            const ambientLight = new THREE.AmbientLight(0xffffff, 2.0);
             scene.add(ambientLight);
 
-            // Add a dim directional light for depth
-            const dirLight = new THREE.DirectionalLight(0xffffff, 0.3);
+            // Directional light for reflections
+            const dirLight = new THREE.DirectionalLight(0xffffff, 1.5);
             dirLight.position.set(1, 1, 1);
             scene.add(dirLight);
+
+            // Second directional light from opposite side
+            const dirLight2 = new THREE.DirectionalLight(0xffffff, 0.8);
+            dirLight2.position.set(-1, -0.5, -1);
+            scene.add(dirLight2);
 
             camera = new THREE.PerspectiveCamera(60, width / height, 0.1, 50000);
             camera.position.set(0, 500, 1500);
@@ -293,7 +307,23 @@
             renderer = new THREE.WebGLRenderer({ antialias: true });
             renderer.setSize(width, height);
             renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+            renderer.toneMapping = THREE.ACESFilmicToneMapping;
+            renderer.toneMappingExposure = 1.0;
             container.appendChild(renderer.domElement);
+
+            // Set up post-processing with selective bloom
+            // High threshold (1.0) means only HDR bright colors (stars) will bloom
+            composer = new EffectComposer(renderer);
+            composer.addPass(new RenderPass(scene, camera));
+
+            const bloomPass = new UnrealBloomPass(
+                new THREE.Vector2(width, height),
+                0.6,   // strength
+                0.05,  // radius (very tight glow)
+                0.85   // threshold
+            );
+            composer.addPass(bloomPass);
+            composer.addPass(new OutputPass());
 
             controls = new OrbitControls(camera, renderer.domElement);
             controls.enableDamping = true;
@@ -318,6 +348,7 @@
             });
             document.getElementById('project-filter').addEventListener('change', loadGraph);
             document.getElementById('search').addEventListener('input', handleSearch);
+            document.getElementById('meditation-mode').addEventListener('change', e => toggleMeditationMode(e.target.checked));
 
             renderer.domElement.addEventListener('mousemove', onMouseMove);
             renderer.domElement.addEventListener('click', onMouseClick);
@@ -350,7 +381,13 @@
             updateHighlightAnimation();
             updateOrbits();
             controls.update();
-            renderer.render(scene, camera);
+
+            // Use post-processing for bloom effect on stars
+            if (composer) {
+                composer.render();
+            } else {
+                renderer.render(scene, camera);
+            }
         }
 
         function updateHighlightAnimation() {
@@ -461,6 +498,7 @@
             camera.aspect = width / height;
             camera.updateProjectionMatrix();
             renderer.setSize(width, height);
+            if (composer) composer.setSize(width, height);
         }
 
         // Smooth zoom - target distance from orbit center
@@ -887,6 +925,11 @@
                 browserUrl.searchParams.set('solution', solutionPath);
                 window.history.replaceState({}, '', browserUrl);
 
+                // Start meditation mode if enabled by default
+                if (meditationMode && !meditationInterval) {
+                    toggleMeditationMode(true);
+                }
+
             } catch (error) {
                 showError(error.message);
             } finally {
@@ -1212,13 +1255,13 @@
                 typeCallers.set(key, current + callers);
             });
 
-            // Create stars (types) as glowing spheres
+            // Create stars (types) as bright glowing spheres that bloom
             if (typeNodes.length > 0) {
                 console.log('Creating', typeNodes.length, 'stars');
                 const starGeometry = new THREE.SphereGeometry(1, 24, 16);
-                // Clean white stars
+                // Bright white stars - will bloom due to high brightness
                 const starMaterial = new THREE.MeshBasicMaterial({
-                    color: 0xffffff
+                    color: new THREE.Color(1.2, 1.2, 1.2) // HDR white - slightly above 1.0, will bloom subtly
                 });
 
                 starsMesh = new THREE.InstancedMesh(starGeometry, starMaterial, typeNodes.length);
@@ -1268,12 +1311,10 @@
 
             // Create planets (members) with sphere geometry - use BasicMaterial so they glow
             if (memberNodes.length > 0) {
-                const sphereGeometry = new THREE.SphereGeometry(1, 10, 8);
-                // MeshBasicMaterial - planets glow on their own, no light needed
+                const sphereGeometry = new THREE.SphereGeometry(1, 16, 12);
+                // MeshBasicMaterial - self-illuminating planets
                 const sphereMaterial = new THREE.MeshBasicMaterial({
-                    color: 0xffffff,
-                    transparent: true,
-                    opacity: 0.9
+                    color: 0xffffff
                 });
 
                 planetsMesh = new THREE.InstancedMesh(sphereGeometry, sphereMaterial, memberNodes.length);
@@ -1557,6 +1598,90 @@
 
         function hideError() {
             document.getElementById('error').classList.remove('visible');
+        }
+
+        // Meditation mode - polls for last symbol and flies to it
+        function toggleMeditationMode(enabled) {
+            meditationMode = enabled;
+            if (enabled) {
+                console.log('Meditation mode enabled - polling every 10 seconds');
+                pollLastSymbol(); // Initial poll
+                meditationInterval = setInterval(pollLastSymbol, 10000);
+            } else {
+                console.log('Meditation mode disabled');
+                if (meditationInterval) {
+                    clearInterval(meditationInterval);
+                    meditationInterval = null;
+                }
+            }
+        }
+
+        async function pollLastSymbol() {
+            if (!meditationMode) return;
+
+            try {
+                const response = await fetch('/api/last-symbol');
+                const data = await response.json();
+
+                if (!data.exists) return;
+
+                // Check if this is a new symbol (different timestamp)
+                const newTimestamp = new Date(data.timestamp).getTime();
+                if (lastSymbolTimestamp === newTimestamp) return;
+
+                lastSymbolTimestamp = newTimestamp;
+                console.log('New symbol detected:', data.qualifiedName);
+
+                // Find the node by qualified name
+                const node = findNodeByQualifiedName(data.qualifiedName);
+                if (node) {
+                    console.log('Flying to:', node.qualifiedName || node.name);
+                    flyToNode(node);
+                    showNodeInfo(node);
+                } else {
+                    console.log('Symbol not found in current view:', data.qualifiedName);
+                }
+            } catch (err) {
+                console.error('Error polling last symbol:', err);
+            }
+        }
+
+        function findNodeByQualifiedName(qualifiedName) {
+            // First try exact match
+            for (const node of graphData.nodes) {
+                if (node.qualifiedName === qualifiedName) {
+                    return node;
+                }
+            }
+
+            // Try matching method (without parameters)
+            const nameWithoutParams = qualifiedName.split('(')[0];
+            for (const node of graphData.nodes) {
+                if (node.qualifiedName === nameWithoutParams) {
+                    return node;
+                }
+            }
+
+            // Try matching just the end part (Type.Method or just Type)
+            const parts = nameWithoutParams.split('.');
+            if (parts.length >= 2) {
+                const shortName = parts.slice(-2).join('.');
+                for (const node of graphData.nodes) {
+                    if (node.qualifiedName && node.qualifiedName.endsWith(shortName)) {
+                        return node;
+                    }
+                }
+            }
+
+            // Try type-only match (for get_type_members)
+            const typeName = parts.slice(-1)[0];
+            for (const node of typeNodes) {
+                if (node.typeName === typeName || node.qualifiedName?.endsWith('.' + typeName)) {
+                    return node;
+                }
+            }
+
+            return null;
         }
 
         init();

--- a/src/LastSymbolTracker.cs
+++ b/src/LastSymbolTracker.cs
@@ -1,0 +1,90 @@
+using System.Text.Json;
+
+namespace RoslynMcpServer;
+
+/// <summary>
+/// Tracks the last symbol processed by MCP tools for visualization sync.
+/// Uses a file-based approach so the Web server can read it.
+/// </summary>
+public static class LastSymbolTracker
+{
+    private static readonly string StateFilePath = Path.Combine(
+        Path.GetTempPath(),
+        "roslyn-mcp-last-symbol.json");
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    /// <summary>
+    /// Records a symbol that was just processed.
+    /// </summary>
+    public static void Track(string solutionPath, string qualifiedName, string? kind = null)
+    {
+        try
+        {
+            var state = new LastSymbolState
+            {
+                SolutionPath = solutionPath,
+                QualifiedName = qualifiedName,
+                Kind = kind,
+                Timestamp = DateTime.UtcNow
+            };
+
+            var json = JsonSerializer.Serialize(state, JsonOptions);
+            File.WriteAllText(StateFilePath, json);
+        }
+        catch
+        {
+            // Silently ignore errors - this is non-critical
+        }
+    }
+
+    /// <summary>
+    /// Gets the last tracked symbol.
+    /// </summary>
+    public static LastSymbolState? GetLast()
+    {
+        try
+        {
+            if (!File.Exists(StateFilePath))
+                return null;
+
+            var json = File.ReadAllText(StateFilePath);
+            return JsonSerializer.Deserialize<LastSymbolState>(json, JsonOptions);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Clears the last tracked symbol.
+    /// </summary>
+    public static void Clear()
+    {
+        try
+        {
+            if (File.Exists(StateFilePath))
+                File.Delete(StateFilePath);
+        }
+        catch
+        {
+            // Silently ignore
+        }
+    }
+}
+
+/// <summary>
+/// State object for last processed symbol.
+/// </summary>
+public class LastSymbolState
+{
+    public string SolutionPath { get; set; } = "";
+    public string QualifiedName { get; set; } = "";
+    public string? Kind { get; set; }
+    public DateTime Timestamp { get; set; }
+}

--- a/src/RoslynTools.Callers.cs
+++ b/src/RoslynTools.Callers.cs
@@ -283,6 +283,9 @@ public static partial class RoslynTools
             })
             .ToList();
 
+        // Track for visualization sync
+        LastSymbolTracker.Track(solutionPath, qualifiedName, "member");
+
         return new GetCallersResult
         {
             Success = true,

--- a/src/RoslynTools.MethodBody.cs
+++ b/src/RoslynTools.MethodBody.cs
@@ -97,6 +97,10 @@ public static partial class RoslynTools
                     methodName,
                     parameterTypes);
 
+                // Track for visualization sync
+                if (result.Success)
+                    LastSymbolTracker.Track(solutionPath, $"{typeName}.{methodName}", "method");
+
                 return new
                 {
                     content = new[]

--- a/src/RoslynTools.TypeMembers.cs
+++ b/src/RoslynTools.TypeMembers.cs
@@ -105,6 +105,10 @@ public static partial class RoslynTools
                     includeInherited,
                     compact);
 
+                // Track for visualization sync
+                if (result.Success)
+                    LastSymbolTracker.Track(solutionPath, typeName, "type");
+
                 return new
                 {
                     content = new[]


### PR DESCRIPTION
## Summary
- Stars now have a subtle glow effect using UnrealBloomPass (WebGL)
- Meditation mode auto-follows Claude's MCP tool activity in real-time
- When Claude uses `roslyn_get_type_members`, `roslyn_get_method_body`, or `roslyn_get_callers`, the visualization automatically flies to that symbol
- Added `LastSymbolTracker.cs` for file-based state sharing between MCP server and web server
- Added `/api/last-symbol` endpoint for polling

## Test plan
- [x] Open visualization at http://localhost:5200
- [x] Load a solution with graph data
- [x] Verify stars have subtle glow effect
- [x] Enable meditation mode (on by default)
- [x] Make MCP tool calls and verify visualization flies to symbols
- [x] Verify info panel updates when flying to symbols

Fixes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)