### PR TITLE
Fix: Remove verbose content from knowledge list/search, add get-by-ID tool

### DIFF
--- a/Instructions/Topics/tools.md
+++ b/Instructions/Topics/tools.md
@@ -66,10 +66,11 @@ You have access to Roslyn MCP tools for C# code analysis. These tools provide se
 | Tool | Purpose |
 |------|---------|
 | `roslyn_knowledge_add` | Add gotchas, patterns, or insights linked to symbols |
-| `roslyn_knowledge_search` | Semantic search using symbol links, FTS5, and vector similarity |
-| `roslyn_knowledge_list` | List entries with optional category/tag filtering |
+| `roslyn_knowledge_search` | Semantic search (returns compact results: id, title, category, tags) |
+| `roslyn_knowledge_list` | List entries (returns compact results: id, title, category, tags) |
+| `roslyn_knowledge_get` | Get full content of a single entry by ID |
 | `roslyn_knowledge_delete` | Delete an entry by ID |
-| `roslyn_knowledge_for_symbol` | Get all knowledge linked to a specific symbol |
+| `roslyn_knowledge_for_symbol` | Get all knowledge linked to a specific symbol (full content) |
 
 Knowledge entries support:
 - **Code-specific categories**: gotcha, pattern, architecture, debugging, performance, security, testing, workaround
@@ -164,6 +165,7 @@ Use native tools (Read, Edit, Grep, Glob) only for:
 3. Next time you work on that symbol, knowledge is searchable
 
 ### Finding relevant knowledge
-1. `roslyn_knowledge_search(query: "caching performance")` → semantic search
-2. `roslyn_knowledge_for_symbol(symbolName: "FeatureLayer.BuildCache")` → exact match
-3. `roslyn_knowledge_list(category: "gotcha")` → browse by category
+1. `roslyn_knowledge_search(query: "caching performance")` → semantic search (compact results)
+2. `roslyn_knowledge_get(id: 5)` → fetch full content for interesting result
+3. `roslyn_knowledge_for_symbol(symbolName: "FeatureLayer.BuildCache")` → exact match (full content)
+4. `roslyn_knowledge_list(category: "gotcha")` → browse by category (compact results)

--- a/README.md
+++ b/README.md
@@ -172,10 +172,11 @@ Plans are stored **per-solution** in `.claude/plans/`:
 | `roslyn_get_instructions` | Get topic-specific instructions (tools, git, code, plan, tdd, pre-pr) |
 | `roslyn_setup_hooks` | Set up Claude Code hooks to enforce instruction reading before git/GitHub operations |
 | `roslyn_knowledge_add` | Add knowledge entries (gotchas, patterns, insights) linked to symbols |
-| `roslyn_knowledge_search` | Semantic search using symbol links, FTS5, and vector similarity |
-| `roslyn_knowledge_list` | List knowledge entries with category/tag filtering |
+| `roslyn_knowledge_search` | Semantic search (returns compact results: id, title, category, tags) |
+| `roslyn_knowledge_list` | List knowledge entries (returns compact results: id, title, category, tags) |
+| `roslyn_knowledge_get` | Get full content of a single entry by ID |
 | `roslyn_knowledge_delete` | Delete a knowledge entry by ID |
-| `roslyn_knowledge_for_symbol` | Get all knowledge linked to a specific symbol |
+| `roslyn_knowledge_for_symbol` | Get all knowledge linked to a specific symbol (full content) |
 
 ### Dead Code Detection Limitations
 

--- a/src/RoslynTools.Knowledge.cs
+++ b/src/RoslynTools.Knowledge.cs
@@ -241,7 +241,6 @@ public static partial class RoslynTools
                             r.Entry.Id,
                             r.Entry.Category,
                             r.Entry.Title,
-                            r.Entry.Content,
                             r.Entry.SymbolLinks,
                             r.Entry.Tags,
                             r.Entry.Confidence,
@@ -341,7 +340,6 @@ public static partial class RoslynTools
                             e.Id,
                             e.Category,
                             e.Title,
-                            e.Content,
                             e.SymbolLinks,
                             e.Tags,
                             e.Confidence,
@@ -426,6 +424,88 @@ public static partial class RoslynTools
                 catch (Exception ex)
                 {
                     return CreateErrorResponse($"Error deleting knowledge: {ex.Message}");
+                }
+            });
+    }
+
+    /// <summary>
+    /// Registers the roslyn_knowledge_get tool.
+    /// </summary>
+    internal static void RegisterKnowledgeGetTool(McpServer server)
+    {
+        server.RegisterTool(
+            "roslyn_knowledge_get",
+            new ToolDefinition
+            {
+                Description = "Gets a single knowledge entry by ID with full content. Use this after searching or listing to fetch complete details.",
+                InputSchema = new
+                {
+                    type = "object",
+                    properties = new
+                    {
+                        solutionPath = new
+                        {
+                            type = "string",
+                            description = "Absolute path to the .sln or .slnx solution file"
+                        },
+                        id = new
+                        {
+                            type = "integer",
+                            description = "ID of the knowledge entry to retrieve"
+                        }
+                    },
+                    required = new[] { "solutionPath", "id" }
+                },
+                Annotations = new ToolAnnotations
+                {
+                    ReadOnlyHint = true,
+                    IdempotentHint = true
+                }
+            },
+            async args =>
+            {
+                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var id = args?["id"]?.GetValue<long>() ?? 0;
+
+                if (string.IsNullOrWhiteSpace(solutionPath))
+                    return CreateErrorResponse("Error: solutionPath is required");
+
+                if (!File.Exists(solutionPath))
+                    return CreateErrorResponse($"Error: Solution file not found: {solutionPath}");
+
+                if (id <= 0)
+                    return CreateErrorResponse("Error: valid id is required");
+
+                try
+                {
+                    var db = await GetKnowledgeDatabaseAsync(solutionPath);
+                    var entry = await db.GetEntryByIdAsync(id);
+
+                    if (entry == null)
+                    {
+                        return CreateErrorResponse($"Error: Knowledge entry {id} not found");
+                    }
+
+                    return CreateJsonResponse(new
+                    {
+                        success = true,
+                        entry = new
+                        {
+                            entry.Id,
+                            entry.Category,
+                            entry.Title,
+                            entry.Content,
+                            entry.SymbolLinks,
+                            entry.Tags,
+                            entry.Confidence,
+                            entry.CreatedAt,
+                            entry.UpdatedAt
+                        }
+                    });
+                }
+                catch (Exception ex)
+                {
+                    return CreateErrorResponse($"Error getting knowledge entry: {ex.Message}");
                 }
             });
     }

--- a/src/RoslynTools.cs
+++ b/src/RoslynTools.cs
@@ -53,6 +53,7 @@ public static partial class RoslynTools
         RegisterKnowledgeSearchTool(server);
         RegisterKnowledgeListTool(server);
         RegisterKnowledgeDeleteTool(server);
+        RegisterKnowledgeGetTool(server);
         RegisterKnowledgeForSymbolTool(server);
     }
 


### PR DESCRIPTION
## Summary
- `roslyn_knowledge_list` now returns compact results (no content field)
- `roslyn_knowledge_search` now returns compact results (no content field)  
- Added `roslyn_knowledge_get` tool to fetch full entry details by ID
- Updated tools.md and README.md documentation

## Test plan
- [x] All 74 tests pass
- [x] Real-world tested on Atlas3.sln with roslyn_knowledge_list and roslyn_knowledge_search
- [x] roslyn_knowledge_get verified to return full content

Fixes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)