### PR TITLE
Feature: Add update-docs skill with Haiku model

### DIFF
--- a/Instructions/Skills/update-docs/SKILL.md
+++ b/Instructions/Skills/update-docs/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: update-docs
+description: Update documentation files (README.md, tools.md, etc.) after code changes. Use when tools are added/modified or features change.
+model: claude-3-5-haiku
+allowed-tools: Read, Write, Edit, Glob, Grep, Bash
+disable-model-invocation: true
+---
+
+# Update Documentation
+
+Update all relevant documentation to reflect recent code changes.
+
+## Steps
+
+1. **Check what changed:**
+   ```bash
+   git diff --name-only HEAD~1
+   ```
+
+2. **For each modified source file, update relevant docs:**
+
+   | If changed... | Update... |
+   |---------------|-----------|
+   | `src/RoslynTools*.cs` | `README.md` (tools table), `Instructions/Topics/tools.md` |
+   | `Instructions/Topics/*.md` | Verify consistency with code |
+   | `Instructions/Hooks/*.py` | `README.md` (setup section) |
+   | New feature added | `README.md` (features section) |
+
+3. **Documentation rules:**
+   - Keep descriptions concise and accurate
+   - Match tool descriptions in README.md with actual tool behavior
+   - Don't add unnecessary commentary or emojis
+   - Preserve existing formatting style
+
+4. **Verify changes:**
+   - Read the updated files to confirm accuracy
+   - Ensure no broken links or references
+
+$ARGUMENTS

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ YourSolution/
     ├── hooks/                         # Workflow enforcement hooks
     │   ├── enforce-git-instructions.py
     │   └── enforce-plan-instructions.py
+    ├── skills/                        # Custom skills (cost-optimized)
+    │   └── update-docs/SKILL.md       # Uses Haiku model (~20x cheaper)
     ├── plans/                         # Plan files (per-solution)
     └── settings.json                  # Hook configuration
 ```
@@ -144,6 +146,29 @@ Plans are stored **per-solution** in `.claude/plans/`:
 - Tracks work across sessions
 - Links to GitHub issues
 - Prevents context loss during long sessions
+
+## Cost-Optimized Skills
+
+The setup includes custom skills that use cheaper models for specific tasks:
+
+| Skill | Model | Cost Savings | Usage |
+|-------|-------|--------------|-------|
+| `/update-docs` | Haiku | ~20x cheaper than Opus | Update README.md, tools.md after code changes |
+
+### Why Use Skills with Cheaper Models?
+
+- **Documentation updates** don't need Opus-level reasoning
+- **Haiku** handles straightforward tasks at 5% of Opus cost
+- Skills specify allowed tools, preventing unnecessary operations
+
+### Using the Update-Docs Skill
+
+After making code changes:
+```
+/update-docs
+```
+
+Claude will use Haiku to update relevant documentation files based on your recent changes.
 
 ## Available Tools
 

--- a/setup.ps1
+++ b/setup.ps1
@@ -28,11 +28,14 @@ Write-Host "Creating directories..." -ForegroundColor White
 $claudeDir = ".claude"
 $hooksDir = Join-Path $claudeDir "hooks"
 $plansDir = Join-Path $claudeDir "plans"
+$skillsDir = Join-Path $claudeDir "skills"
 
 New-Item -ItemType Directory -Path $hooksDir -Force | Out-Null
 New-Item -ItemType Directory -Path $plansDir -Force | Out-Null
+New-Item -ItemType Directory -Path $skillsDir -Force | Out-Null
 Write-Host "  Created: $hooksDir" -ForegroundColor Gray
 Write-Host "  Created: $plansDir" -ForegroundColor Gray
+Write-Host "  Created: $skillsDir" -ForegroundColor Gray
 
 # Copy hook files
 Write-Host ""
@@ -47,6 +50,23 @@ if (Test-Path $sourceHooksDir) {
 } else {
     Write-Host "  ERROR: Hook source files not found at $sourceHooksDir" -ForegroundColor Red
     exit 1
+}
+
+# Copy skills
+Write-Host ""
+Write-Host "Installing skills..." -ForegroundColor White
+$sourceSkillsDir = Join-Path $RoslynMcpPath "Instructions\Skills"
+
+if (Test-Path $sourceSkillsDir) {
+    $skillFolders = Get-ChildItem -Path $sourceSkillsDir -Directory
+    foreach ($skill in $skillFolders) {
+        $destSkillDir = Join-Path $skillsDir $skill.Name
+        New-Item -ItemType Directory -Path $destSkillDir -Force | Out-Null
+        Copy-Item -Path (Join-Path $skill.FullName "*") -Destination $destSkillDir -Recurse -Force
+        Write-Host "  Installed: $($skill.Name) (uses Haiku model)" -ForegroundColor Gray
+    }
+} else {
+    Write-Host "  No skills found at $sourceSkillsDir - skipping" -ForegroundColor Yellow
 }
 
 # Create settings.json
@@ -144,6 +164,7 @@ Write-Host ""
 Write-Host "Files created:" -ForegroundColor White
 Write-Host "  .claude/hooks/enforce-git-instructions.py" -ForegroundColor Gray
 Write-Host "  .claude/hooks/enforce-plan-instructions.py" -ForegroundColor Gray
+Write-Host "  .claude/skills/update-docs/ (Haiku model)" -ForegroundColor Gray
 Write-Host "  .claude/settings.json" -ForegroundColor Gray
 Write-Host "  .claude/plans/ (directory)" -ForegroundColor Gray
 if (-not (Test-Path $claudeMdFile -PathType Leaf)) {


### PR DESCRIPTION
## Summary
- Added `/update-docs` skill that uses Haiku model (~20x cheaper than Opus)
- Updated `setup.ps1` to copy skills to target projects
- Updated `README.md` with Cost-Optimized Skills section

## Usage
After making code changes:
```
/update-docs
```

## Test plan
- [x] Skill file created with correct frontmatter
- [x] setup.ps1 copies skills directory
- [x] README.md documents the feature

Fixes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)