### PR TITLE
Fix: Improve symbol lookup for MCP tools (#68)

### DIFF
--- a/RoslynMcpServer.Graph/GraphDatabase.Symbols.cs
+++ b/RoslynMcpServer.Graph/GraphDatabase.Symbols.cs
@@ -85,14 +85,16 @@ public sealed partial class GraphDatabase
             // Fall through to normal search if constructor search found nothing
         }
 
-        // 3. Try partial matching - search for symbols ending with the search term
-        // This handles: "MethodName", "Type.MethodName", "Namespace.Type.MethodName"
+        // 3. Try partial matching with multiple strategies (Issue #68)
+        // - Prefix match: "Namespace.Type.Method" matches "Namespace.Type.Method(params)"
+        // - Suffix match: "Type.Method" or "Method" matches "...Type.Method(params)"
         var candidates = await _connection.QueryAsync<SymbolRecord>(
             """
             SELECT Id, SolutionId, Kind, Name, QualifiedName, FilePath, Line, Column, BodyHash, ContainingTypeId, Status, LastAnalyzed
             FROM Symbols
             WHERE SolutionId = @SolutionId
-              AND (QualifiedName LIKE '%.' || @SearchName || '(%'
+              AND (QualifiedName LIKE @SearchName || '(%'
+                   OR QualifiedName LIKE '%.' || @SearchName || '(%'
                    OR QualifiedName LIKE '%.' || @SearchName
                    OR Name = @SearchName)
             """,

--- a/src/SolutionAnalyzerService.AddMember.cs
+++ b/src/SolutionAnalyzerService.AddMember.cs
@@ -328,4 +328,41 @@ public partial class SolutionAnalyzerService
         }
         return fixableIds;
     }
+
+
+    private static async Task<ISymbol?> FindSymbolAtPositionWithToleranceAsync(
+            SemanticModel semanticModel,
+            int position,
+            Workspace workspace)
+    {
+        // First try exact position
+        var symbol = await SymbolFinder.FindSymbolAtPositionAsync(semanticModel, position, workspace);
+        if (symbol != null) return symbol;
+
+        // Get the syntax root and try to find a token at this position
+        var syntaxRoot = await semanticModel.SyntaxTree.GetRootAsync();
+        var token = syntaxRoot.FindToken(position);
+
+        // If position is within the token (not at start), try the token's start position
+        if (token.SpanStart < position && position < token.Span.End)
+        {
+            symbol = await SymbolFinder.FindSymbolAtPositionAsync(semanticModel, token.SpanStart, workspace);
+            if (symbol != null) return symbol;
+        }
+
+        // Try the parent node - sometimes the position is on a child but the symbol is on the parent
+        var node = token.Parent;
+        while (node != null)
+        {
+            symbol = semanticModel.GetDeclaredSymbol(node);
+            if (symbol != null) return symbol;
+
+            symbol = semanticModel.GetSymbolInfo(node).Symbol;
+            if (symbol != null) return symbol;
+
+            node = node.Parent;
+        }
+
+        return null;
+    }
 }

--- a/src/SolutionAnalyzerService.Callers.cs
+++ b/src/SolutionAnalyzerService.Callers.cs
@@ -80,7 +80,8 @@ public partial class SolutionAnalyzerService
             var text = await document.GetTextAsync();
             var position = text.Lines[line - 1].Start + (column - 1);
 
-            var symbol = await SymbolFinder.FindSymbolAtPositionAsync(semanticModel, position, workspace);
+            // Use tolerant symbol finder (Issue #68)
+            var symbol = await FindSymbolAtPositionWithToleranceAsync(semanticModel, position, workspace);
 
             if (symbol == null)
             {

--- a/src/SolutionAnalyzerService.References.cs
+++ b/src/SolutionAnalyzerService.References.cs
@@ -101,7 +101,8 @@ public partial class SolutionAnalyzerService
             var text = await document.GetTextAsync();
             var position = text.Lines[line - 1].Start + (column - 1);
 
-            var symbol = await SymbolFinder.FindSymbolAtPositionAsync(semanticModel, position, workspace);
+            // Use tolerant symbol finder (Issue #68)
+            var symbol = await FindSymbolAtPositionWithToleranceAsync(semanticModel, position, workspace);
 
             if (symbol == null)
             {


### PR DESCRIPTION
## Summary
- Add prefix matching to `FindSymbolAsync` for qualified names without parameters
  - `"Namespace.Type.Method"` now matches `"Namespace.Type.Method(params)"`
- Add `FindSymbolAtPositionWithToleranceAsync` helper for position-based lookups
  - Tries exact position first
  - Falls back to token start position
  - Finally tries parent node symbols
- Update `FindReferencesAsync` and `GetCallersAsync` to use tolerant lookup

## Root Causes Fixed
1. **Graph queries** (roslyn_query_graph, roslyn_graph_impact): The SQL only did suffix matching, missing prefix matches for full qualified names
2. **Position-based queries** (roslyn_get_references, roslyn_get_callers): `SymbolFinder.FindSymbolAtPositionAsync` is strict - if column is 1 char off, it fails

## Test plan
- [x] All 80 tests pass
- [x] Build succeeds with no warnings

Fixes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)