### PR TITLE
Feature: Make Read/Edit hooks use tokens for hard blocking

### DIFF
--- a/.claude/plans/issue-79.md
+++ b/.claude/plans/issue-79.md
@@ -1,0 +1,42 @@
+# Plan: Make Read/Edit hooks use tokens for hard blocking
+
+## Problem Statement
+Read/Edit hooks for C# files are soft suggestions (exit 0). Need to make them hard blocks (exit 2) like git/plan hooks.
+
+## Implementation
+
+### Changes needed:
+1. Rename hooks to reflect enforcement behavior
+2. Update hook code to exit with code 2 (block) when no valid token
+3. Update RoslynTools.SetupHooks.cs with new filenames
+4. Update README.md hook enforcement table
+
+### Token already works:
+- `roslyn_get_instructions("tools")` already writes `roslyn-tools-token-{hash}`
+- Hooks already check for this token
+- Just need to change exit code from 0 to 2
+
+## Completed Changes
+
+1. Updated `Instructions/Hooks/suggest-roslyn-for-read.py`:
+   - Changed from soft suggestion (exit 0) to hard block (exit 2)
+   - Added HTTP validation like git hooks
+   - Added local fallback validation
+
+2. Updated `Instructions/Hooks/suggest-roslyn-for-csharp.py`:
+   - Changed from soft suggestion (exit 0) to hard block (exit 2)
+   - Added HTTP validation like git hooks
+   - Removed bypass marker support (no longer needed)
+
+3. Updated `README.md`:
+   - Changed hook table from "Soft suggestion" to "BLOCKED - requires valid tools token"
+
+4. Updated `src/RoslynTools.SetupHooks.cs`:
+   - Updated instruction messages to reflect blocking behavior
+
+## Test Results
+- Build: SUCCESS
+- Tests: 88/88 passed
+
+## Current Status
+COMPLETED - Ready for commit and PR

--- a/Instructions/Hooks/suggest-roslyn-for-csharp.py
+++ b/Instructions/Hooks/suggest-roslyn-for-csharp.py
@@ -1,26 +1,26 @@
 #!/usr/bin/env python3
 """
-Hook: Suggest Roslyn MCP tools for C# file edits.
+Hook: Enforce calling roslyn_get_instructions("tools") before Edit/Write on C# files.
 
-This hook shows a SUGGESTION when Edit/Write is used on .cs files,
-recommending Roslyn tools for semantic code modifications.
-Uses exit code 0 (allow) with a message to avoid "hook error" presentation.
+This hook BLOCKS Edit/Write operations on .cs files unless a valid tools token exists.
+Forces Claude to use Roslyn MCP tools (roslyn_update_method, roslyn_add_member, etc.) for C# code.
 
-The suggestion is skipped if:
-1. roslyn_get_instructions("tools") was called recently for the same solution (1 min token)
-2. The content includes a bypass marker: // ROSLYN_BYPASS: <reason>
+Tokens are per-solution (based on solution file hash) and valid for 1 minute.
 
-The bypass marker should explain why Roslyn tools aren't being used, e.g.:
-  // ROSLYN_BYPASS: Adding comment to non-compiled file
-  // ROSLYN_BYPASS: Creating new file, will use roslyn_add_member after
-  // ROSLYN_BYPASS: Editing .csproj embedded C# code
+Flow:
+1. roslyn_get_instructions("tools") generates a token and writes to ~/.claude/roslyn-tools-token-{hash}
+2. This hook reads the token and validates it (file age < 1 min)
+3. If valid, Edit/Write is allowed
+4. If invalid/missing, Edit/Write is BLOCKED with helpful message
 """
 import sys
 import json
 import os
 import time
-import re
 import hashlib
+import urllib.request
+import urllib.error
+import urllib.parse
 
 
 def find_solution_file(file_path):
@@ -33,10 +33,13 @@ def find_solution_file(file_path):
             break
 
         # Check for solution files
-        for ext in ['.slnx', '.sln']:
-            for item in os.listdir(current):
-                if item.endswith(ext):
-                    return os.path.join(current, item)
+        try:
+            for ext in ['.slnx', '.sln']:
+                for item in os.listdir(current):
+                    if item.endswith(ext):
+                        return os.path.join(current, item)
+        except:
+            pass
 
         current = os.path.dirname(current)
 
@@ -58,55 +61,66 @@ def get_token_file_path(solution_path):
     return os.path.join(home, ".claude", f"roslyn-tools-token-{solution_hash}")
 
 
-def get_log_file_path():
-    """Get path to the suggestions log file."""
-    home = os.path.expanduser("~")
-    return os.path.join(home, ".claude", "roslyn-suggestions.log")
-
-
-def is_token_valid(solution_path):
-    """Check if a valid (non-expired) tools token exists for this solution."""
-    token_file = get_token_file_path(solution_path)
-
-    if not os.path.exists(token_file):
-        return False, "No token file found"
-
+def get_hook_port():
+    """Read the port number from the port file."""
+    port_file = os.path.join(os.path.expanduser('~'), '.claude', 'roslyn-hook-port')
     try:
-        # Check file age (token valid for 1 minute)
-        file_age = time.time() - os.path.getmtime(token_file)
-        max_age = 1 * 60  # 1 minute in seconds
+        with open(port_file, 'r') as f:
+            return int(f.read().strip())
+    except:
+        return None
 
-        if file_age > max_age:
-            return False, f"Token expired ({file_age/60:.1f} minutes old, max 1 minute)"
 
-        # Token exists and is fresh
-        return True, "Valid token"
+def get_tools_token(solution_path):
+    """Read the tools token from the per-solution token file."""
+    token_file = get_token_file_path(solution_path)
+    try:
+        with open(token_file, 'r') as f:
+            return f.read().strip()
+    except:
+        return None
+
+
+def validate_token_http(token, port):
+    """Validate token via HTTP endpoint."""
+    try:
+        encoded_token = urllib.parse.quote(token, safe='')
+        url = f'http://localhost:{port}/validate?token={encoded_token}&topic=tools'
+        with urllib.request.urlopen(url, timeout=5) as response:
+            data = json.loads(response.read().decode('utf-8'))
+            return data.get('valid', False), data.get('message', 'Unknown error')
+    except urllib.error.URLError as e:
+        return False, f'Cannot connect to validation server: {e.reason}'
     except Exception as e:
-        return False, f"Error reading token: {e}"
+        return False, f'Validation error: {e}'
 
 
-def has_bypass_marker(content):
-    """Check if content contains a ROSLYN_BYPASS marker with a reason."""
-    if not content:
-        return False, None
+def validate_token_local(token):
+    """Fallback: validate token locally by checking timestamp."""
+    try:
+        parts = token.split('.')
+        if len(parts) != 4:
+            return False, 'Invalid token format'
 
-    # Match: // ROSLYN_BYPASS: <reason>
-    pattern = r'//\s*ROSLYN_BYPASS:\s*(.+)'
-    match = re.search(pattern, content)
+        timestamp = int(parts[1])
+        age_seconds = time.time() - timestamp
 
-    if match:
-        reason = match.group(1).strip()
-        if reason:
-            return True, reason
+        if age_seconds > 60:  # 1 minute
+            return False, f'Token expired ({age_seconds/60:.1f} minutes old, max 1 minute)'
 
-    return False, None
+        if age_seconds < 0:
+            return False, 'Token timestamp is in the future'
+
+        return True, f'Valid ({age_seconds:.0f}s old)'
+    except Exception as e:
+        return False, f'Local validation error: {e}'
 
 
 def main():
     try:
         data = json.load(sys.stdin)
     except:
-        sys.exit(0)  # Can't parse input, allow (fail-safe)
+        sys.exit(0)  # Can't parse input, allow
 
     tool_name = data.get('tool_name', '')
     tool_input = data.get('tool_input', {})
@@ -119,41 +133,30 @@ def main():
     # Find solution file for this C# file
     solution_path = find_solution_file(file_path)
 
-    # Check for valid token (from roslyn_get_instructions("tools"))
-    token_valid, token_msg = is_token_valid(solution_path)
-    if token_valid:
-        # Token is valid, allow the operation
-        print(f'[Roslyn Hook] Token valid - allowing {tool_name} on C# file', file=sys.stderr)
-        sys.exit(0)
+    # Get the token
+    token = get_tools_token(solution_path)
+    if not token:
+        solution_info = f' for {os.path.basename(solution_path)}' if solution_path else ''
+        print(f'BLOCKED: No tools token found{solution_info}.', file=sys.stderr)
+        print('Run: roslyn_get_instructions(topic: "tools") before editing C# files.', file=sys.stderr)
+        print('Alternative: Use roslyn_update_method or roslyn_add_member instead of Edit/Write.', file=sys.stderr)
+        sys.exit(2)
 
-    # Check for bypass marker in content
-    content_to_check = ""
-    if tool_name == "Edit":
-        content_to_check = tool_input.get('new_string', '')
-    elif tool_name == "Write":
-        content_to_check = tool_input.get('content', '')
+    # Try HTTP validation first
+    port = get_hook_port()
+    if port:
+        valid, message = validate_token_http(token, port)
+    else:
+        # Fallback to local validation
+        valid, message = validate_token_local(token)
 
-    has_bypass, bypass_reason = has_bypass_marker(content_to_check)
-    if has_bypass:
-        print(f'[Roslyn Hook] Bypass accepted: {bypass_reason}', file=sys.stderr)
-        sys.exit(0)
-
-    # Write suggestion to log file (Claude Code doesn't display stdout for exit 0)
-    from datetime import datetime
-    log_file = get_log_file_path()
-    try:
-        with open(log_file, 'a') as f:
-            f.write(f'\n[{datetime.now().strftime("%H:%M:%S")}] {tool_name}: {file_path}\n')
-            if solution_path:
-                f.write(f'  Solution: {os.path.basename(solution_path)}\n')
-            f.write(f'  Token: {token_msg}\n')
-            f.write('  Suggestion: Use Roslyn tools (roslyn_update_method, roslyn_add_member, etc.)\n')
-            f.write('  Alternative: Add // ROSLYN_BYPASS: <reason> to skip this suggestion\n')
-    except:
-        pass  # Don't fail if logging fails
-
-    # Exit 0 - allow the operation (suggestion logged to ~/.claude/roslyn-suggestions.log)
-    sys.exit(0)
+    if valid:
+        sys.exit(0)  # Allow
+    else:
+        print(f'BLOCKED: {message}', file=sys.stderr)
+        print('Run: roslyn_get_instructions(topic: "tools") before editing C# files.', file=sys.stderr)
+        print('Alternative: Use roslyn_update_method or roslyn_add_member instead of Edit/Write.', file=sys.stderr)
+        sys.exit(2)
 
 
 if __name__ == '__main__':

--- a/Instructions/Hooks/suggest-roslyn-for-read.py
+++ b/Instructions/Hooks/suggest-roslyn-for-read.py
@@ -1,19 +1,26 @@
 #!/usr/bin/env python3
 """
-Hook: Suggest Roslyn MCP tools for reading C# files.
+Hook: Enforce calling roslyn_get_instructions("tools") before Read on C# files.
 
-This hook shows a SUGGESTION when Read is used on .cs files,
-recommending Roslyn tools for semantic code understanding.
-Uses exit code 0 (allow) with a message to avoid "hook error" presentation.
+This hook BLOCKS Read operations on .cs files unless a valid tools token exists.
+Forces Claude to use Roslyn MCP tools (roslyn_get_method_body, etc.) for C# code.
 
-The suggestion is skipped if roslyn_get_instructions("tools") was called recently
-for the same solution. Tokens are per-solution and valid for 1 minute.
+Tokens are per-solution (based on solution file hash) and valid for 1 minute.
+
+Flow:
+1. roslyn_get_instructions("tools") generates a token and writes to ~/.claude/roslyn-tools-token-{hash}
+2. This hook reads the token and validates it (file age < 1 min)
+3. If valid, Read is allowed
+4. If invalid/missing, Read is BLOCKED with helpful message
 """
 import sys
 import json
 import os
 import time
 import hashlib
+import urllib.request
+import urllib.error
+import urllib.parse
 
 
 def find_solution_file(file_path):
@@ -26,10 +33,13 @@ def find_solution_file(file_path):
             break
 
         # Check for solution files
-        for ext in ['.slnx', '.sln']:
-            for item in os.listdir(current):
-                if item.endswith(ext):
-                    return os.path.join(current, item)
+        try:
+            for ext in ['.slnx', '.sln']:
+                for item in os.listdir(current):
+                    if item.endswith(ext):
+                        return os.path.join(current, item)
+        except:
+            pass
 
         current = os.path.dirname(current)
 
@@ -51,25 +61,59 @@ def get_token_file_path(solution_path):
     return os.path.join(home, ".claude", f"roslyn-tools-token-{solution_hash}")
 
 
-def get_log_file_path():
-    """Get path to the suggestions log file."""
-    home = os.path.expanduser("~")
-    return os.path.join(home, ".claude", "roslyn-suggestions.log")
-
-
-def is_token_valid(solution_path):
-    """Check if a valid (non-expired) tools token exists for this solution."""
-    token_file = get_token_file_path(solution_path)
-
-    if not os.path.exists(token_file):
-        return False
-
+def get_hook_port():
+    """Read the port number from the port file."""
+    port_file = os.path.join(os.path.expanduser('~'), '.claude', 'roslyn-hook-port')
     try:
-        file_age = time.time() - os.path.getmtime(token_file)
-        max_age = 1 * 60  # 1 minute
-        return file_age <= max_age
+        with open(port_file, 'r') as f:
+            return int(f.read().strip())
     except:
-        return False
+        return None
+
+
+def get_tools_token(solution_path):
+    """Read the tools token from the per-solution token file."""
+    token_file = get_token_file_path(solution_path)
+    try:
+        with open(token_file, 'r') as f:
+            return f.read().strip()
+    except:
+        return None
+
+
+def validate_token_http(token, port):
+    """Validate token via HTTP endpoint."""
+    try:
+        encoded_token = urllib.parse.quote(token, safe='')
+        url = f'http://localhost:{port}/validate?token={encoded_token}&topic=tools'
+        with urllib.request.urlopen(url, timeout=5) as response:
+            data = json.loads(response.read().decode('utf-8'))
+            return data.get('valid', False), data.get('message', 'Unknown error')
+    except urllib.error.URLError as e:
+        return False, f'Cannot connect to validation server: {e.reason}'
+    except Exception as e:
+        return False, f'Validation error: {e}'
+
+
+def validate_token_local(token):
+    """Fallback: validate token locally by checking timestamp."""
+    try:
+        parts = token.split('.')
+        if len(parts) != 4:
+            return False, 'Invalid token format'
+
+        timestamp = int(parts[1])
+        age_seconds = time.time() - timestamp
+
+        if age_seconds > 60:  # 1 minute
+            return False, f'Token expired ({age_seconds/60:.1f} minutes old, max 1 minute)'
+
+        if age_seconds < 0:
+            return False, 'Token timestamp is in the future'
+
+        return True, f'Valid ({age_seconds:.0f}s old)'
+    except Exception as e:
+        return False, f'Local validation error: {e}'
 
 
 def main():
@@ -81,31 +125,37 @@ def main():
     tool_input = data.get('tool_input', {})
     file_path = tool_input.get('file_path', '')
 
-    # Only suggest for .cs files
+    # Only enforce for .cs files
     if not file_path.lower().endswith('.cs'):
         sys.exit(0)  # Not a C# file, allow silently
 
     # Find solution file for this C# file
     solution_path = find_solution_file(file_path)
 
-    # If they already called roslyn_get_instructions("tools") for this solution, allow
-    if is_token_valid(solution_path):
-        sys.exit(0)  # Already aware of Roslyn tools
+    # Get the token
+    token = get_tools_token(solution_path)
+    if not token:
+        solution_info = f' for {os.path.basename(solution_path)}' if solution_path else ''
+        print(f'BLOCKED: No tools token found{solution_info}.', file=sys.stderr)
+        print('Run: roslyn_get_instructions(topic: "tools") before reading C# files.', file=sys.stderr)
+        print('Alternative: Use roslyn_get_method_body or roslyn_get_type_members instead of Read.', file=sys.stderr)
+        sys.exit(2)
 
-    # Write suggestion to log file (Claude Code doesn't display stdout for exit 0)
-    from datetime import datetime
-    log_file = get_log_file_path()
-    try:
-        with open(log_file, 'a') as f:
-            f.write(f'\n[{datetime.now().strftime("%H:%M:%S")}] Read: {file_path}\n')
-            if solution_path:
-                f.write(f'  Solution: {os.path.basename(solution_path)}\n')
-            f.write('  Suggestion: Use Roslyn tools for C# files (roslyn_get_type_members, roslyn_get_method_body, etc.)\n')
-    except:
-        pass  # Don't fail if logging fails
+    # Try HTTP validation first
+    port = get_hook_port()
+    if port:
+        valid, message = validate_token_http(token, port)
+    else:
+        # Fallback to local validation
+        valid, message = validate_token_local(token)
 
-    # Exit 0 - allow the Read (suggestion logged to ~/.claude/roslyn-suggestions.log)
-    sys.exit(0)
+    if valid:
+        sys.exit(0)  # Allow
+    else:
+        print(f'BLOCKED: {message}', file=sys.stderr)
+        print('Run: roslyn_get_instructions(topic: "tools") before reading C# files.', file=sys.stderr)
+        print('Alternative: Use roslyn_get_method_body or roslyn_get_type_members instead of Read.', file=sys.stderr)
+        sys.exit(2)
 
 
 if __name__ == '__main__':

--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ The server includes hooks that enforce Claude to read instructions before perfor
 | `git commit`, `git push` | BLOCKED - requires valid git token | 1 minute |
 | `gh issue create/close/edit` | BLOCKED - requires valid plan token | 1 minute |
 | `gh pr create/merge` | BLOCKED - requires valid plan token | 1 minute |
-| `Read` on `.cs` files | Soft suggestion - logged to `~/.claude/roslyn-suggestions.log` | 1 minute |
-| `Edit`/`Write` on `.cs` files | Soft suggestion - logged to `~/.claude/roslyn-suggestions.log` | 1 minute |
+| `Read` on `.cs` files | BLOCKED - requires valid tools token | 1 minute |
+| `Edit`/`Write` on `.cs` files | BLOCKED - requires valid tools token | 1 minute |
 
 Tokens are **per-solution** (hash-based filenames) and expire after **1 minute**.
 

--- a/src/RoslynTools.SetupHooks.cs
+++ b/src/RoslynTools.SetupHooks.cs
@@ -242,8 +242,8 @@ public static partial class RoslynTools
             {
                 "The git hook requires calling roslyn_get_instructions(topic: \"git\") before any git commit or push.",
                 "The plan hook requires calling roslyn_get_instructions(topic: \"plan\") before GitHub issue/PR operations.",
-                "The C# edit hook suggests using Roslyn MCP tools for .cs file edits (soft reminder, can be ignored if not applicable).",
-                "The C# read hook requires calling roslyn_get_instructions(topic: \"tools\") before reading .cs files."
+                "The C# edit hook requires calling roslyn_get_instructions(topic: \"tools\") before Edit/Write on .cs files.",
+                "The C# read hook requires calling roslyn_get_instructions(topic: \"tools\") before Read on .cs files."
             }
         };
     }


### PR DESCRIPTION
## Summary
- Changed `suggest-roslyn-for-read.py` to block Read on `.cs` files without valid tools token
- Changed `suggest-roslyn-for-csharp.py` to block Edit/Write on `.cs` files without valid tools token
- Both hooks now use HTTP validation (with local fallback) like git/plan hooks
- Updated README.md hook enforcement table
- Updated setup instructions

## What this changes

Previously, the Read/Edit hooks for C# files were "soft suggestions" - they logged to `~/.claude/roslyn-suggestions.log` but always allowed the operation. Claude could ignore them.

Now they are "hard blocks" - like the git and plan hooks:
- Require calling `roslyn_get_instructions(topic: "tools")` first
- Token is per-solution (hash-based filename)
- Token expires after 1 minute

This forces Claude to use Roslyn MCP tools for C# code:
- `roslyn_get_method_body` instead of `Read`
- `roslyn_update_method` instead of `Edit`
- `roslyn_add_member` instead of `Write`

## Test plan
- [x] All 88 tests pass
- [x] Build succeeds with no warnings

Fixes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)