### PR TITLE
Fix: Require solutionPath for roslyn_get_instructions token generation

### DIFF
--- a/.claude/hooks/enforce-git-instructions.py
+++ b/.claude/hooks/enforce-git-instructions.py
@@ -49,9 +49,13 @@ def find_solution_file(start_dir=None):
 
 
 def get_solution_hash(solution_path):
-    """Get a short hash of the solution path for unique token filename."""
+    """Get a short hash of the solution path for unique token filename.
+
+    Returns None if no solution path provided - caller must handle this case.
+    Global tokens are not supported.
+    """
     if not solution_path:
-        return "global"
+        return None
     # Use first 8 chars of MD5 hash
     return hashlib.md5(solution_path.lower().encode()).hexdigest()[:8]
 
@@ -127,13 +131,17 @@ def main():
 
     # Find solution file from current working directory
     solution_path = find_solution_file()
+    if not solution_path:
+        print('BLOCKED: No solution file (.sln or .slnx) found.', file=sys.stderr)
+        print('Run: roslyn_get_instructions(topic: "git", solutionPath: "<path>") with the correct solution path.', file=sys.stderr)
+        print('Find the solution file first with: glob pattern "*.sln*"', file=sys.stderr)
+        sys.exit(2)
 
     # Get the token
     token = get_git_token(solution_path)
     if not token:
-        solution_info = f' for {os.path.basename(solution_path)}' if solution_path else ''
-        print(f'BLOCKED: No git token found{solution_info}.', file=sys.stderr)
-        print('Run: roslyn_get_instructions(topic: "git") before committing.', file=sys.stderr)
+        print(f'BLOCKED: No git token found for {os.path.basename(solution_path)}.', file=sys.stderr)
+        print(f'Run: roslyn_get_instructions(topic: "git", solutionPath: "{solution_path}")', file=sys.stderr)
         sys.exit(2)
 
     # Try HTTP validation first

--- a/.claude/hooks/enforce-plan-instructions.py
+++ b/.claude/hooks/enforce-plan-instructions.py
@@ -49,9 +49,13 @@ def find_solution_file(start_dir=None):
 
 
 def get_solution_hash(solution_path):
-    """Get a short hash of the solution path for unique token filename."""
+    """Get a short hash of the solution path for unique token filename.
+
+    Returns None if no solution path provided - caller must handle this case.
+    Global tokens are not supported.
+    """
     if not solution_path:
-        return "global"
+        return None
     # Use first 8 chars of MD5 hash
     return hashlib.md5(solution_path.lower().encode()).hexdigest()[:8]
 
@@ -127,13 +131,17 @@ def main():
 
     # Find solution file from current working directory
     solution_path = find_solution_file()
+    if not solution_path:
+        print('BLOCKED: No solution file (.sln or .slnx) found.', file=sys.stderr)
+        print('Run: roslyn_get_instructions(topic: "plan", solutionPath: "<path>") with the correct solution path.', file=sys.stderr)
+        print('Find the solution file first with: glob pattern "*.sln*"', file=sys.stderr)
+        sys.exit(2)
 
     # Get the token
     token = get_plan_token(solution_path)
     if not token:
-        solution_info = f' for {os.path.basename(solution_path)}' if solution_path else ''
-        print(f'BLOCKED: No plan token found{solution_info}.', file=sys.stderr)
-        print('Run: roslyn_get_instructions(topic: "plan") before GitHub operations.', file=sys.stderr)
+        print(f'BLOCKED: No plan token found for {os.path.basename(solution_path)}.', file=sys.stderr)
+        print(f'Run: roslyn_get_instructions(topic: "plan", solutionPath: "{solution_path}")', file=sys.stderr)
         print('This ensures you have read the plan file and are tracking your work.', file=sys.stderr)
         sys.exit(2)
 

--- a/.claude/hooks/suggest-roslyn-for-csharp.py
+++ b/.claude/hooks/suggest-roslyn-for-csharp.py
@@ -47,9 +47,13 @@ def find_solution_file(file_path):
 
 
 def get_solution_hash(solution_path):
-    """Get a short hash of the solution path for unique token filename."""
+    """Get a short hash of the solution path for unique token filename.
+
+    Returns None if no solution path provided - caller must handle this case.
+    Global tokens are not supported.
+    """
     if not solution_path:
-        return "global"
+        return None
     # Use first 8 chars of MD5 hash
     return hashlib.md5(solution_path.lower().encode()).hexdigest()[:8]
 
@@ -132,13 +136,17 @@ def main():
 
     # Find solution file for this C# file
     solution_path = find_solution_file(file_path)
+    if not solution_path:
+        print('BLOCKED: No solution file (.sln or .slnx) found.', file=sys.stderr)
+        print('Run: roslyn_get_instructions(topic: "tools", solutionPath: "<path>") with the correct solution path.', file=sys.stderr)
+        print('Find the solution file first with: glob pattern "*.sln*"', file=sys.stderr)
+        sys.exit(2)
 
     # Get the token
     token = get_tools_token(solution_path)
     if not token:
-        solution_info = f' for {os.path.basename(solution_path)}' if solution_path else ''
-        print(f'BLOCKED: No tools token found{solution_info}.', file=sys.stderr)
-        print('Run: roslyn_get_instructions(topic: "tools") before editing C# files.', file=sys.stderr)
+        print(f'BLOCKED: No tools token found for {os.path.basename(solution_path)}.', file=sys.stderr)
+        print(f'Run: roslyn_get_instructions(topic: "tools", solutionPath: "{solution_path}")', file=sys.stderr)
         print('Alternative: Use roslyn_update_method or roslyn_add_member instead of Edit/Write.', file=sys.stderr)
         sys.exit(2)
 

--- a/.claude/hooks/suggest-roslyn-for-read.py
+++ b/.claude/hooks/suggest-roslyn-for-read.py
@@ -47,9 +47,13 @@ def find_solution_file(file_path):
 
 
 def get_solution_hash(solution_path):
-    """Get a short hash of the solution path for unique token filename."""
+    """Get a short hash of the solution path for unique token filename.
+
+    Returns None if no solution path provided - caller must handle this case.
+    Global tokens are not supported.
+    """
     if not solution_path:
-        return "global"
+        return None
     # Use first 8 chars of MD5 hash
     return hashlib.md5(solution_path.lower().encode()).hexdigest()[:8]
 
@@ -131,13 +135,17 @@ def main():
 
     # Find solution file for this C# file
     solution_path = find_solution_file(file_path)
+    if not solution_path:
+        print('BLOCKED: No solution file (.sln or .slnx) found.', file=sys.stderr)
+        print('Run: roslyn_get_instructions(topic: "tools", solutionPath: "<path>") with the correct solution path.', file=sys.stderr)
+        print('Find the solution file first with: glob pattern "*.sln*"', file=sys.stderr)
+        sys.exit(2)
 
     # Get the token
     token = get_tools_token(solution_path)
     if not token:
-        solution_info = f' for {os.path.basename(solution_path)}' if solution_path else ''
-        print(f'BLOCKED: No tools token found{solution_info}.', file=sys.stderr)
-        print('Run: roslyn_get_instructions(topic: "tools") before reading C# files.', file=sys.stderr)
+        print(f'BLOCKED: No tools token found for {os.path.basename(solution_path)}.', file=sys.stderr)
+        print(f'Run: roslyn_get_instructions(topic: "tools", solutionPath: "{solution_path}")', file=sys.stderr)
         print('Alternative: Use roslyn_get_method_body or roslyn_get_type_members instead of Read.', file=sys.stderr)
         sys.exit(2)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,11 @@
 
 ## MANDATORY: Start Every Session with Plan Instructions
 
-**Before doing anything else**, call `roslyn_get_instructions("plan")` and follow those instructions.
+**Before doing anything else:**
+1. Find the solution file: `glob pattern "*.sln*"`
+2. Call `roslyn_get_instructions(topic: "plan", solutionPath: "<path>")` and follow those instructions.
+
+**Note:** The `solutionPath` parameter is REQUIRED for `plan`, `git`, and `tools` topics to generate per-solution tokens for hook validation.
 
 ## MANDATORY: Get Instructions Before Operations
 

--- a/CLAUDE_TEMPLATE.md
+++ b/CLAUDE_TEMPLATE.md
@@ -4,7 +4,11 @@
 
 ## MANDATORY: Start Every Session with Plan Instructions
 
-**Before doing anything else**, call `roslyn_get_instructions("plan")` and follow those instructions.
+**Before doing anything else:**
+1. Find the solution file: `glob pattern "*.sln*"`
+2. Call `roslyn_get_instructions(topic: "plan", solutionPath: "<path>")` and follow those instructions.
+
+**Note:** The `solutionPath` parameter is REQUIRED for `plan`, `git`, and `tools` topics to generate per-solution tokens for hook validation.
 
 ## MANDATORY: Get Instructions Before Operations
 

--- a/Instructions/Hooks/enforce-git-instructions.py
+++ b/Instructions/Hooks/enforce-git-instructions.py
@@ -49,9 +49,13 @@ def find_solution_file(start_dir=None):
 
 
 def get_solution_hash(solution_path):
-    """Get a short hash of the solution path for unique token filename."""
+    """Get a short hash of the solution path for unique token filename.
+
+    Returns None if no solution path provided - caller must handle this case.
+    Global tokens are not supported.
+    """
     if not solution_path:
-        return "global"
+        return None
     # Use first 8 chars of MD5 hash
     return hashlib.md5(solution_path.lower().encode()).hexdigest()[:8]
 
@@ -127,13 +131,17 @@ def main():
 
     # Find solution file from current working directory
     solution_path = find_solution_file()
+    if not solution_path:
+        print('BLOCKED: No solution file (.sln or .slnx) found.', file=sys.stderr)
+        print('Run: roslyn_get_instructions(topic: "git", solutionPath: "<path>") with the correct solution path.', file=sys.stderr)
+        print('Find the solution file first with: glob pattern "*.sln*"', file=sys.stderr)
+        sys.exit(2)
 
     # Get the token
     token = get_git_token(solution_path)
     if not token:
-        solution_info = f' for {os.path.basename(solution_path)}' if solution_path else ''
-        print(f'BLOCKED: No git token found{solution_info}.', file=sys.stderr)
-        print('Run: roslyn_get_instructions(topic: "git") before committing.', file=sys.stderr)
+        print(f'BLOCKED: No git token found for {os.path.basename(solution_path)}.', file=sys.stderr)
+        print(f'Run: roslyn_get_instructions(topic: "git", solutionPath: "{solution_path}")', file=sys.stderr)
         sys.exit(2)
 
     # Try HTTP validation first

--- a/Instructions/Hooks/enforce-plan-instructions.py
+++ b/Instructions/Hooks/enforce-plan-instructions.py
@@ -49,9 +49,13 @@ def find_solution_file(start_dir=None):
 
 
 def get_solution_hash(solution_path):
-    """Get a short hash of the solution path for unique token filename."""
+    """Get a short hash of the solution path for unique token filename.
+
+    Returns None if no solution path provided - caller must handle this case.
+    Global tokens are not supported.
+    """
     if not solution_path:
-        return "global"
+        return None
     # Use first 8 chars of MD5 hash
     return hashlib.md5(solution_path.lower().encode()).hexdigest()[:8]
 
@@ -127,13 +131,17 @@ def main():
 
     # Find solution file from current working directory
     solution_path = find_solution_file()
+    if not solution_path:
+        print('BLOCKED: No solution file (.sln or .slnx) found.', file=sys.stderr)
+        print('Run: roslyn_get_instructions(topic: "plan", solutionPath: "<path>") with the correct solution path.', file=sys.stderr)
+        print('Find the solution file first with: glob pattern "*.sln*"', file=sys.stderr)
+        sys.exit(2)
 
     # Get the token
     token = get_plan_token(solution_path)
     if not token:
-        solution_info = f' for {os.path.basename(solution_path)}' if solution_path else ''
-        print(f'BLOCKED: No plan token found{solution_info}.', file=sys.stderr)
-        print('Run: roslyn_get_instructions(topic: "plan") before GitHub operations.', file=sys.stderr)
+        print(f'BLOCKED: No plan token found for {os.path.basename(solution_path)}.', file=sys.stderr)
+        print(f'Run: roslyn_get_instructions(topic: "plan", solutionPath: "{solution_path}")', file=sys.stderr)
         print('This ensures you have read the plan file and are tracking your work.', file=sys.stderr)
         sys.exit(2)
 

--- a/Instructions/Hooks/suggest-roslyn-for-csharp.py
+++ b/Instructions/Hooks/suggest-roslyn-for-csharp.py
@@ -47,9 +47,13 @@ def find_solution_file(file_path):
 
 
 def get_solution_hash(solution_path):
-    """Get a short hash of the solution path for unique token filename."""
+    """Get a short hash of the solution path for unique token filename.
+
+    Returns None if no solution path provided - caller must handle this case.
+    Global tokens are not supported.
+    """
     if not solution_path:
-        return "global"
+        return None
     # Use first 8 chars of MD5 hash
     return hashlib.md5(solution_path.lower().encode()).hexdigest()[:8]
 
@@ -132,13 +136,17 @@ def main():
 
     # Find solution file for this C# file
     solution_path = find_solution_file(file_path)
+    if not solution_path:
+        print('BLOCKED: No solution file (.sln or .slnx) found.', file=sys.stderr)
+        print('Run: roslyn_get_instructions(topic: "tools", solutionPath: "<path>") with the correct solution path.', file=sys.stderr)
+        print('Find the solution file first with: glob pattern "*.sln*"', file=sys.stderr)
+        sys.exit(2)
 
     # Get the token
     token = get_tools_token(solution_path)
     if not token:
-        solution_info = f' for {os.path.basename(solution_path)}' if solution_path else ''
-        print(f'BLOCKED: No tools token found{solution_info}.', file=sys.stderr)
-        print('Run: roslyn_get_instructions(topic: "tools") before editing C# files.', file=sys.stderr)
+        print(f'BLOCKED: No tools token found for {os.path.basename(solution_path)}.', file=sys.stderr)
+        print(f'Run: roslyn_get_instructions(topic: "tools", solutionPath: "{solution_path}")', file=sys.stderr)
         print('Alternative: Use roslyn_update_method or roslyn_add_member instead of Edit/Write.', file=sys.stderr)
         sys.exit(2)
 

--- a/Instructions/Hooks/suggest-roslyn-for-read.py
+++ b/Instructions/Hooks/suggest-roslyn-for-read.py
@@ -47,9 +47,13 @@ def find_solution_file(file_path):
 
 
 def get_solution_hash(solution_path):
-    """Get a short hash of the solution path for unique token filename."""
+    """Get a short hash of the solution path for unique token filename.
+
+    Returns None if no solution path provided - caller must handle this case.
+    Global tokens are not supported.
+    """
     if not solution_path:
-        return "global"
+        return None
     # Use first 8 chars of MD5 hash
     return hashlib.md5(solution_path.lower().encode()).hexdigest()[:8]
 
@@ -131,13 +135,17 @@ def main():
 
     # Find solution file for this C# file
     solution_path = find_solution_file(file_path)
+    if not solution_path:
+        print('BLOCKED: No solution file (.sln or .slnx) found.', file=sys.stderr)
+        print('Run: roslyn_get_instructions(topic: "tools", solutionPath: "<path>") with the correct solution path.', file=sys.stderr)
+        print('Find the solution file first with: glob pattern "*.sln*"', file=sys.stderr)
+        sys.exit(2)
 
     # Get the token
     token = get_tools_token(solution_path)
     if not token:
-        solution_info = f' for {os.path.basename(solution_path)}' if solution_path else ''
-        print(f'BLOCKED: No tools token found{solution_info}.', file=sys.stderr)
-        print('Run: roslyn_get_instructions(topic: "tools") before reading C# files.', file=sys.stderr)
+        print(f'BLOCKED: No tools token found for {os.path.basename(solution_path)}.', file=sys.stderr)
+        print(f'Run: roslyn_get_instructions(topic: "tools", solutionPath: "{solution_path}")', file=sys.stderr)
         print('Alternative: Use roslyn_get_method_body or roslyn_get_type_members instead of Read.', file=sys.stderr)
         sys.exit(2)
 

--- a/Instructions/Templates/standard.md
+++ b/Instructions/Templates/standard.md
@@ -4,7 +4,11 @@
 
 ## MANDATORY: Start Every Session with Plan Instructions
 
-**Before doing anything else**, call `roslyn_get_instructions("plan")` and follow those instructions.
+**Before doing anything else:**
+1. Find the solution file: `glob pattern "*.sln*"`
+2. Call `roslyn_get_instructions(topic: "plan", solutionPath: "<path>")` and follow those instructions.
+
+**Note:** The `solutionPath` parameter is REQUIRED for `plan`, `git`, and `tools` topics to generate per-solution tokens for hook validation.
 
 ## MANDATORY: Get Instructions Before Operations
 

--- a/Instructions/Topics/tools.md
+++ b/Instructions/Topics/tools.md
@@ -60,7 +60,9 @@ You have access to Roslyn MCP tools for C# code analysis. These tools provide se
 | Tool | Purpose |
 |------|---------|
 | `roslyn_get_template` | Get CLAUDE.md template for projects |
-| `roslyn_get_instructions` | Get topic-specific development instructions |
+| `roslyn_get_instructions` | Get topic-specific development instructions (see note below) |
+
+**Important:** When calling `roslyn_get_instructions` with `plan`, `git`, or `tools` topics, the `solutionPath` parameter is **required** to generate per-solution tokens for hook validation. Find the solution file first with glob pattern `*.sln*`.
 
 ### Knowledge Base (Semantic Search)
 

--- a/README.md
+++ b/README.md
@@ -107,14 +107,16 @@ If Claude uses `roslyn_find_symbol`, everything is working.
 
 The template tells Claude to fetch topic-specific instructions via `roslyn_get_instructions`:
 
-| Topic | Description |
-|-------|-------------|
-| `plan` | Session planning, issue tracking, plan file management |
-| `tools` | Roslyn tool preferences and usage |
-| `git` | Git workflow, branches, commits, **unit testing** |
-| `code` | C# best practices |
-| `tdd` | Test-driven development |
-| `pre-pr` | Checklist before creating pull request |
+| Topic | Description | solutionPath |
+|-------|-------------|--------------|
+| `plan` | Session planning, issue tracking, plan file management | **Required** |
+| `tools` | Roslyn tool preferences and usage | **Required** |
+| `git` | Git workflow, branches, commits, **unit testing** | **Required** |
+| `code` | C# best practices | Optional |
+| `tdd` | Test-driven development | Optional |
+| `pre-pr` | Checklist before creating pull request | Optional |
+
+**Important:** The `solutionPath` parameter is **required** for `plan`, `git`, and `tools` topics to generate per-solution tokens for hook validation. Find the solution file first with `glob pattern "*.sln*"`.
 
 ## Why CLAUDE.md Matters
 
@@ -145,7 +147,7 @@ The server includes hooks that enforce Claude to read instructions before perfor
 | `Read` on `.cs` files | BLOCKED - requires valid tools token | 1 minute |
 | `Edit`/`Write` on `.cs` files | BLOCKED - requires valid tools token | 1 minute |
 
-Tokens are **per-solution** (hash-based filenames) and expire after **1 minute**.
+Tokens are **per-solution** (hash-based filenames) and expire after **1 minute**. Global tokens are not supported - Claude must always provide the `solutionPath` parameter when calling `roslyn_get_instructions` for plan/git/tools topics.
 
 ### Plan Files
 

--- a/src/RoslynTools.Instructions.cs
+++ b/src/RoslynTools.Instructions.cs
@@ -97,7 +97,7 @@ public static partial class RoslynTools
                         solutionPath = new
                         {
                             type = "string",
-                            description = "Optional: Absolute path to the .sln or .slnx solution file. Required for 'tools' topic to generate per-solution token."
+                            description = "Absolute path to the .sln or .slnx solution file. REQUIRED for 'git', 'plan', and 'tools' topics to generate the correct per-solution token. Without this, a 'global' token is generated which won't match per-solution hook validation. Find the solution file first with glob pattern '*.sln*' before calling this tool."
                         }
                     },
                     required = new[] { "topic" }


### PR DESCRIPTION
## Summary
- Updated tool description to clearly state solutionPath is REQUIRED for git/plan/tools topics
- Modified all 4 hooks to reject global tokens and require per-solution tokens
- Updated all documentation (README, CLAUDE.md, templates, tools.md)

## Changes
- `src/RoslynTools.Instructions.cs` - Updated solutionPath description
- `.claude/hooks/*.py` - Reject requests when no solution file found
- `Instructions/Hooks/*.py` - Synced from .claude/hooks/
- `README.md` - Added solutionPath column to Available Topics table
- `CLAUDE.md`, `CLAUDE_TEMPLATE.md`, `Instructions/Templates/standard.md` - Updated to show correct calling convention
- `Instructions/Topics/tools.md` - Added note about solutionPath requirement

## Test plan
- [x] All 88 tests pass
- [x] Build succeeds with 0 warnings/errors
- [x] Hooks synced from .claude/ to Instructions/

Fixes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)