### PR TITLE
Feature: Auto-add .claude and .roslyn-mcp to .gitignore

### DIFF
--- a/.claude/plans/issue-81.md
+++ b/.claude/plans/issue-81.md
@@ -1,0 +1,37 @@
+# Plan: Add .claude and .roslyn-mcp to .gitignore automatically
+
+## Problem Statement
+When users install RoslynMcpServer in a new solution, the `.claude` and `.roslyn-mcp` folders should be automatically added to the project's `.gitignore`. Currently, `roslyn_setup_hooks` creates these folders but doesn't update `.gitignore`, potentially causing users to accidentally commit local Claude configuration.
+
+## Completed Fixes
+
+### 1. Added `UpdateGitignore` helper method
+**File:** `src/RoslynTools.AddMember.cs` (added via roslyn_add_member)
+
+New private static method that:
+- Creates `.gitignore` with entries if it doesn't exist
+- Appends entries if file exists but entries are missing
+- Skips if entries already present (with or without trailing slash)
+
+### 2. Updated `SetupHooksInProject` method
+**File:** `src/RoslynTools.SetupHooks.cs`
+
+- Added call to `UpdateGitignore` after creating directories
+- Added `gitignore` property to return object with action and path
+- Updated `filesCreated` list to include gitignore when created/updated
+
+### 3. Added unit tests
+**File:** `RoslynMcpServer.Tests/Services/SetupHooksTests.cs`
+
+5 tests covering:
+- Creating new .gitignore
+- Appending to existing .gitignore
+- Skipping when entries already present
+- Adding only missing entries
+- Recognizing entries without trailing slash
+
+## Test Results
+All 93 tests pass (88 original + 5 new)
+
+## Current Status
+Implementation complete. Ready for commit.

--- a/RoslynMcpServer.Tests/Services/SetupHooksTests.cs
+++ b/RoslynMcpServer.Tests/Services/SetupHooksTests.cs
@@ -1,0 +1,122 @@
+namespace RoslynMcpServer.Tests.Services;
+
+/// <summary>
+/// Tests for the roslyn_setup_hooks tool.
+/// Issue: #81
+/// </summary>
+public class SetupHooksTests : IDisposable
+{
+    private readonly string _tempDir;
+
+    public SetupHooksTests()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"SetupHooksTest_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            Directory.Delete(_tempDir, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void UpdateGitignore_NoExistingFile_CreatesWithEntries()
+    {
+        // Arrange
+        var gitignorePath = Path.Combine(_tempDir, ".gitignore");
+
+        // Act
+        var result = InvokeUpdateGitignore(gitignorePath);
+
+        // Assert
+        Assert.Equal("created", result);
+        Assert.True(File.Exists(gitignorePath));
+
+        var content = File.ReadAllText(gitignorePath);
+        Assert.Contains(".claude/", content);
+        Assert.Contains(".roslyn-mcp/", content);
+    }
+
+    [Fact]
+    public void UpdateGitignore_ExistingFile_AppendsEntries()
+    {
+        // Arrange
+        var gitignorePath = Path.Combine(_tempDir, ".gitignore");
+        File.WriteAllText(gitignorePath, "bin/\nobj/\n");
+
+        // Act
+        var result = InvokeUpdateGitignore(gitignorePath);
+
+        // Assert
+        Assert.Equal("updated", result);
+
+        var content = File.ReadAllText(gitignorePath);
+        Assert.Contains("bin/", content);
+        Assert.Contains("obj/", content);
+        Assert.Contains(".claude/", content);
+        Assert.Contains(".roslyn-mcp/", content);
+    }
+
+    [Fact]
+    public void UpdateGitignore_AlreadyHasEntries_SkipsUpdate()
+    {
+        // Arrange
+        var gitignorePath = Path.Combine(_tempDir, ".gitignore");
+        File.WriteAllText(gitignorePath, "bin/\n.claude/\n.roslyn-mcp/\n");
+
+        // Act
+        var result = InvokeUpdateGitignore(gitignorePath);
+
+        // Assert
+        Assert.Equal("skipped (entries already present)", result);
+    }
+
+    [Fact]
+    public void UpdateGitignore_HasClaudeOnly_AddsRoslynMcp()
+    {
+        // Arrange
+        var gitignorePath = Path.Combine(_tempDir, ".gitignore");
+        File.WriteAllText(gitignorePath, "bin/\n.claude/\n");
+
+        // Act
+        var result = InvokeUpdateGitignore(gitignorePath);
+
+        // Assert
+        Assert.Equal("updated", result);
+
+        var content = File.ReadAllText(gitignorePath);
+        Assert.Contains(".roslyn-mcp/", content);
+    }
+
+    [Fact]
+    public void UpdateGitignore_EntriesWithoutTrailingSlash_RecognizedAsPresent()
+    {
+        // Arrange
+        var gitignorePath = Path.Combine(_tempDir, ".gitignore");
+        File.WriteAllText(gitignorePath, "bin/\n.claude\n.roslyn-mcp\n");
+
+        // Act
+        var result = InvokeUpdateGitignore(gitignorePath);
+
+        // Assert
+        Assert.Equal("skipped (entries already present)", result);
+    }
+
+    /// <summary>
+    /// Invokes the private UpdateGitignore method via reflection.
+    /// </summary>
+    private static string InvokeUpdateGitignore(string gitignorePath)
+    {
+        var method = typeof(RoslynTools).GetMethod(
+            "UpdateGitignore",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static);
+
+        Assert.NotNull(method);
+
+        var result = method.Invoke(null, [gitignorePath]);
+        return (string)result!;
+    }
+}

--- a/src/RoslynTools.AddMember.cs
+++ b/src/RoslynTools.AddMember.cs
@@ -127,4 +127,50 @@ public static partial class RoslynTools
             Console.Error.WriteLine($"Warning: Could not write token file {fileName}: {ex.Message}");
         }
     }
+
+
+    private static string UpdateGitignore(string gitignorePath)
+    {
+        var entriesToAdd = new List<string>();
+        var existingContent = "";
+
+        if (File.Exists(gitignorePath))
+        {
+            existingContent = File.ReadAllText(gitignorePath);
+            var lines = existingContent.Split('\n').Select(l => l.Trim()).ToHashSet();
+
+            // Check if entries already exist (with or without trailing slash)
+            if (!lines.Contains(".claude") && !lines.Contains(".claude/"))
+            {
+                entriesToAdd.Add(".claude/");
+            }
+            if (!lines.Contains(".roslyn-mcp") && !lines.Contains(".roslyn-mcp/"))
+            {
+                entriesToAdd.Add(".roslyn-mcp/");
+            }
+
+            if (entriesToAdd.Count == 0)
+            {
+                return "skipped (entries already present)";
+            }
+
+            // Append new entries
+            var newContent = existingContent.TrimEnd();
+            if (!newContent.EndsWith("\n"))
+            {
+                newContent += "\n";
+            }
+            newContent += "\n# Claude Code and Roslyn MCP (local configuration)\n";
+            newContent += string.Join("\n", entriesToAdd) + "\n";
+            File.WriteAllText(gitignorePath, newContent);
+            return "updated";
+        }
+        else
+        {
+            // Create new .gitignore with entries
+            var content = "# Claude Code and Roslyn MCP (local configuration)\n.claude/\n.roslyn-mcp/\n";
+            File.WriteAllText(gitignorePath, content);
+            return "created";
+        }
+    }
 }

--- a/src/RoslynTools.SetupHooks.cs
+++ b/src/RoslynTools.SetupHooks.cs
@@ -99,6 +99,7 @@ public static partial class RoslynTools
         var roslynSuggestHookFile = Path.Combine(hooksDir, "suggest-roslyn-for-csharp.py");
         var roslynReadHookFile = Path.Combine(hooksDir, "suggest-roslyn-for-read.py");
         var claudeMdFile = Path.Combine(projectPath, "CLAUDE.md");
+        var gitignoreFile = Path.Combine(projectPath, ".gitignore");
 
         // Create directories
         Directory.CreateDirectory(hooksDir);
@@ -109,6 +110,9 @@ public static partial class RoslynTools
         File.WriteAllText(planHookFile, GetHookContent("enforce-plan-instructions.py"));
         File.WriteAllText(roslynSuggestHookFile, GetHookContent("suggest-roslyn-for-csharp.py"));
         File.WriteAllText(roslynReadHookFile, GetHookContent("suggest-roslyn-for-read.py"));
+
+        // Handle .gitignore - add .claude/ and .roslyn-mcp/ entries
+        var gitignoreAction = UpdateGitignore(gitignoreFile);
 
         // Handle CLAUDE.md
         var templateContent = Instructions.Templates.Get(templateName);
@@ -226,6 +230,10 @@ public static partial class RoslynTools
         {
             filesCreated.Add(claudeMdFile);
         }
+        if (gitignoreAction == "created" || gitignoreAction == "updated")
+        {
+            filesCreated.Add(gitignoreFile);
+        }
 
         return new
         {
@@ -237,6 +245,11 @@ public static partial class RoslynTools
             {
                 action = claudeMdAction,
                 path = claudeMdFile
+            },
+            gitignore = new
+            {
+                action = gitignoreAction,
+                path = gitignoreFile
             },
             instructions = new[]
             {


### PR DESCRIPTION
## Summary
- When `roslyn_setup_hooks` is called, it now automatically updates or creates the project's `.gitignore` file
- Adds `.claude/` and `.roslyn-mcp/` entries to prevent accidental commits of local configuration
- Returns gitignore action in the result object (created/updated/skipped)

## Changes
- Added `UpdateGitignore` helper method in `RoslynTools.AddMember.cs`
- Updated `SetupHooksInProject` to call `UpdateGitignore` and include result in response
- Added 5 unit tests covering all gitignore scenarios

## Test plan
- [x] All 93 tests pass
- [x] No new errors or warnings
- [x] Unit tests cover: create new, append to existing, skip if present, partial entries

Fixes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)