### PR TITLE
Fix: Prevent file path injection vulnerability in GraphApi

### DIFF
--- a/RoslynMcpServer.Tests/RoslynMcpServer.Tests.csproj
+++ b/RoslynMcpServer.Tests/RoslynMcpServer.Tests.csproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <ProjectReference Include="..\RoslynMcpServer.csproj" />
     <ProjectReference Include="..\RoslynMcpServer.Graph\RoslynMcpServer.Graph.csproj" />
+    <ProjectReference Include="..\RoslynMcpServer.Web\RoslynMcpServer.Web.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/RoslynMcpServer.Tests/Web/GraphApiSecurityTests.cs
+++ b/RoslynMcpServer.Tests/Web/GraphApiSecurityTests.cs
@@ -1,0 +1,100 @@
+namespace RoslynMcpServer.Tests.Web;
+
+public class GraphApiSecurityTests
+{
+
+
+    [Fact]
+    public void IsValidSolutionPath_NullPath_ReturnsFalse()
+    {
+        // Arrange & Act
+        var result = RoslynMcpServer.Web.GraphApi.IsValidSolutionPath(null, out var normalizedPath, out var errorMessage);
+
+        // Assert
+        Assert.False(result);
+        Assert.Null(normalizedPath);
+        Assert.Equal("solutionPath query parameter is required", errorMessage);
+    }
+
+
+    [Fact]
+    public void IsValidSolutionPath_EmptyPath_ReturnsFalse()
+    {
+        // Arrange & Act
+        var result = RoslynMcpServer.Web.GraphApi.IsValidSolutionPath("", out var normalizedPath, out var errorMessage);
+
+        // Assert
+        Assert.False(result);
+        Assert.Null(normalizedPath);
+        Assert.Equal("solutionPath query parameter is required", errorMessage);
+    }
+
+
+    [Theory]
+    [InlineData("C:\\test\\file.txt")]
+    [InlineData("C:\\test\\file.cs")]
+    [InlineData("C:\\test\\file.csproj")]
+    [InlineData("C:\\test\\file.dll")]
+    [InlineData("C:\\test\\file.exe")]
+    [InlineData("/etc/passwd")]
+    public void IsValidSolutionPath_NonSolutionExtension_ReturnsFalse(string path)
+    {
+        // Arrange & Act
+        var result = RoslynMcpServer.Web.GraphApi.IsValidSolutionPath(path, out var normalizedPath, out var errorMessage);
+
+        // Assert
+        Assert.False(result);
+        Assert.Null(normalizedPath);
+        Assert.Equal("Only .sln and .slnx files are allowed", errorMessage);
+    }
+
+
+    [Theory]
+    [InlineData("C:\\test\\..\\..\\..\\Windows\\System32\\config\\SAM.sln")]
+    [InlineData("C:\\test\\folder\\..\\..\\secret.sln")]
+    public void IsValidSolutionPath_PathTraversal_NormalizesAndRejectsNonexistent(string path)
+    {
+        // Arrange & Act
+        // Path traversal sequences are normalized by Path.GetFullPath()
+        var result = RoslynMcpServer.Web.GraphApi.IsValidSolutionPath(path, out var normalizedPath, out var errorMessage);
+
+        // Assert
+        Assert.False(result);
+        // The path is normalized (traversal resolved) then checked for existence
+        Assert.Equal("Solution file not found", errorMessage);
+    }
+
+
+    [Theory]
+    [InlineData("C:\\nonexistent\\solution.sln")]
+    [InlineData("C:\\nonexistent\\solution.slnx")]
+    public void IsValidSolutionPath_NonExistentFile_ReturnsFalse(string path)
+    {
+        // Arrange & Act
+        var result = RoslynMcpServer.Web.GraphApi.IsValidSolutionPath(path, out var normalizedPath, out var errorMessage);
+
+        // Assert
+        Assert.False(result);
+        Assert.Null(normalizedPath);
+        Assert.Equal("Solution file not found", errorMessage);
+    }
+
+
+    [Theory]
+    [InlineData(".sln")]
+    [InlineData(".SLN")]
+    [InlineData(".slnx")]
+    [InlineData(".SLNX")]
+    public void IsValidSolutionPath_CaseInsensitiveExtension_AcceptsValidExtensions(string extension)
+    {
+        // Arrange
+        var path = $"C:\\test\\solution{extension}";
+
+        // Act
+        var result = RoslynMcpServer.Web.GraphApi.IsValidSolutionPath(path, out var normalizedPath, out var errorMessage);
+
+        // Assert
+        Assert.False(result); // File doesn't exist
+        Assert.Equal("Solution file not found", errorMessage); // But extension was accepted
+    }
+}

--- a/RoslynMcpServer.Web/GraphApi.cs
+++ b/RoslynMcpServer.Web/GraphApi.cs
@@ -129,24 +129,21 @@ public static class GraphApi
     {
         var solutionPath = context.Request.Query["solutionPath"].FirstOrDefault();
 
-        if (string.IsNullOrEmpty(solutionPath))
+        if (!IsValidSolutionPath(solutionPath, out var validatedPath, out var errorMessage))
         {
-            return Results.BadRequest(new { error = "solutionPath query parameter is required" });
+            return errorMessage!.Contains("not found")
+                ? Results.NotFound(new { error = errorMessage })
+                : Results.BadRequest(new { error = errorMessage });
         }
 
-        if (!File.Exists(solutionPath))
-        {
-            return Results.NotFound(new { error = "Solution file not found" });
-        }
-
-        using var db = new GraphDatabase(solutionPath);
+        using var db = new GraphDatabase(validatedPath!);
         if (!db.Exists())
         {
             return Results.Ok(new { exists = false, message = "No graph database exists. Run roslyn_graph_analyze first." });
         }
 
         await db.OpenAsync();
-        var solution = await db.GetSolutionAsync(solutionPath);
+        var solution = await db.GetSolutionAsync(validatedPath!);
 
         if (solution == null)
         {
@@ -176,19 +173,21 @@ public static class GraphApi
     {
         var solutionPath = context.Request.Query["solutionPath"].FirstOrDefault();
 
-        if (string.IsNullOrEmpty(solutionPath))
+        if (!IsValidSolutionPath(solutionPath, out var validatedPath, out var errorMessage))
         {
-            return Results.BadRequest(new { error = "solutionPath query parameter is required" });
+            return errorMessage!.Contains("not found")
+                ? Results.NotFound(new { error = errorMessage })
+                : Results.BadRequest(new { error = errorMessage });
         }
 
-        using var db = new GraphDatabase(solutionPath);
+        using var db = new GraphDatabase(validatedPath!);
         if (!db.Exists())
         {
             return Results.NotFound(new { error = "No graph database exists." });
         }
 
         await db.OpenAsync();
-        var solution = await db.GetSolutionAsync(solutionPath);
+        var solution = await db.GetSolutionAsync(validatedPath!);
 
         if (solution == null)
         {
@@ -207,24 +206,21 @@ public static class GraphApi
         var solutionPath = context.Request.Query["solutionPath"].FirstOrDefault();
         var projectFilter = context.Request.Query["project"].FirstOrDefault();
 
-        if (string.IsNullOrEmpty(solutionPath))
+        if (!IsValidSolutionPath(solutionPath, out var validatedPath, out var errorMessage))
         {
-            return Results.BadRequest(new { error = "solutionPath query parameter is required" });
+            return errorMessage!.Contains("not found")
+                ? Results.NotFound(new { error = errorMessage })
+                : Results.BadRequest(new { error = errorMessage });
         }
 
-        if (!File.Exists(solutionPath))
-        {
-            return Results.NotFound(new { error = "Solution file not found" });
-        }
-
-        using var db = new GraphDatabase(solutionPath);
+        using var db = new GraphDatabase(validatedPath!);
         if (!db.Exists())
         {
             return Results.NotFound(new { error = "No graph database exists. Run roslyn_graph_analyze first." });
         }
 
         await db.OpenAsync();
-        var solution = await db.GetSolutionAsync(solutionPath);
+        var solution = await db.GetSolutionAsync(validatedPath!);
 
         if (solution == null)
         {
@@ -315,12 +311,14 @@ public static class GraphApi
     {
         var solutionPath = context.Request.Query["solutionPath"].FirstOrDefault();
 
-        if (string.IsNullOrEmpty(solutionPath))
+        if (!IsValidSolutionPath(solutionPath, out var validatedPath, out var errorMessage))
         {
-            return Results.BadRequest(new { error = "solutionPath query parameter is required" });
+            return errorMessage!.Contains("not found")
+                ? Results.NotFound(new { error = errorMessage })
+                : Results.BadRequest(new { error = errorMessage });
         }
 
-        using var db = new GraphDatabase(solutionPath);
+        using var db = new GraphDatabase(validatedPath!);
         if (!db.Exists())
         {
             return Results.NotFound(new { error = "No graph database exists." });
@@ -353,5 +351,48 @@ public static class GraphApi
             callers = callers.Select(c => new { c.Id, c.Name, c.QualifiedName }),
             callees = callees.Select(c => new { c.Id, c.Name, c.QualifiedName })
         });
+    }
+
+
+    internal static bool IsValidSolutionPath(string? userPath, out string? normalizedPath, out string? errorMessage)
+    {
+        normalizedPath = null;
+        errorMessage = null;
+
+        if (string.IsNullOrWhiteSpace(userPath))
+        {
+            errorMessage = "solutionPath query parameter is required";
+            return false;
+        }
+
+        try
+        {
+            // Normalize the path to resolve any ../ sequences
+            var fullPath = Path.GetFullPath(userPath);
+
+            // Validate file extension - only allow solution files
+            var extension = Path.GetExtension(fullPath);
+            if (!extension.Equals(".sln", StringComparison.OrdinalIgnoreCase) &&
+                !extension.Equals(".slnx", StringComparison.OrdinalIgnoreCase))
+            {
+                errorMessage = "Only .sln and .slnx files are allowed";
+                return false;
+            }
+
+            // Check if file exists
+            if (!File.Exists(fullPath))
+            {
+                errorMessage = "Solution file not found";
+                return false;
+            }
+
+            normalizedPath = fullPath;
+            return true;
+        }
+        catch (Exception ex) when (ex is ArgumentException or PathTooLongException or NotSupportedException)
+        {
+            errorMessage = "Invalid path format";
+            return false;
+        }
     }
 }

--- a/RoslynMcpServer.Web/RoslynMcpServer.Web.csproj
+++ b/RoslynMcpServer.Web/RoslynMcpServer.Web.csproj
@@ -9,6 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="RoslynMcpServer.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\RoslynMcpServer.Graph\RoslynMcpServer.Graph.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary
- Added `IsValidSolutionPath()` validation method to prevent path traversal attacks
- Validates paths with `Path.GetFullPath()` to resolve `../` sequences
- Restricts to `.sln` and `.slnx` file extensions only
- Applied validation to all 4 GraphApi endpoints (GetSolutions, GetGraph, GetProjects, GetNode)
- Added 16 security unit tests

## Security Issue (CA3003)
User input from HTTP query parameters was flowing directly to `File.Exists()` without validation, enabling:
- File system probing (information disclosure)
- Path traversal attacks
- Sensitive file discovery

## Test plan
- [x] All 16 security tests pass
- [x] No compiler errors
- [x] Build succeeds

Fixes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)