### PR TITLE
Feature: Add roslyn_remove_unnecessary_usings tool

### DIFF
--- a/Instructions/Topics/tools.md
+++ b/Instructions/Topics/tools.md
@@ -35,6 +35,7 @@ You have access to Roslyn MCP tools for C# code analysis. These tools provide se
 | `roslyn_get_diagnostics` | Get compiler errors and warnings |
 | `roslyn_apply_code_fix` | Apply Roslyn's suggested fix for one diagnostic |
 | `roslyn_batch_apply_code_fixes` | Fix all diagnostics of a specific type |
+| `roslyn_remove_unnecessary_usings` | Remove CS8019 (unnecessary using) directives from files |
 
 ### Call Graph (Cached Analysis)
 
@@ -110,6 +111,7 @@ Knowledge entries support:
 | Check errors | `roslyn_get_diagnostics` | dotnet build output is harder to parse |
 | Fix warning | `roslyn_apply_code_fix` | Manual edit may introduce errors |
 | Fix many warnings | `roslyn_batch_apply_code_fixes` | One-by-one is slow |
+| Remove unused usings | `roslyn_remove_unnecessary_usings` | CS8019 has no batch code fix provider |
 | Rename | `roslyn_rename_symbol` | Find/replace misses some references |
 | Extract method | `roslyn_extract_method` | Manual extraction misses params/returns |
 | Document a gotcha | `roslyn_knowledge_add` | Comments get lost, knowledge persists |
@@ -181,6 +183,13 @@ Creates `MyApp.Core/Services/UserService.cs` with namespace `MyApp.Core.Services
 1. `roslyn_get_diagnostics(severityFilter: "warning")` → see all warnings
 2. `roslyn_get_diagnostics(diagnosticId: "CS8618")` → get details
 3. `roslyn_batch_apply_code_fixes(diagnosticId: "CS8618")` → auto-fix
+
+### Removing unnecessary usings (CS8019)
+1. `roslyn_remove_unnecessary_usings(solutionPath, preview: true)` → preview what will be removed
+2. `roslyn_remove_unnecessary_usings(solutionPath)` → remove all unnecessary usings
+3. Automatically skips generated files in obj/ folders
+
+**Note:** CS8019 (unnecessary using) requires this dedicated tool because Roslyn's code fix provider for it needs IDE services not available in batch mode.
 
 ### Documenting code learnings
 1. After fixing a tricky bug or discovering a gotcha:

--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ Uses Haiku model (~20x cheaper than Opus) for straightforward documentation upda
 | `roslyn_get_diagnostics` | Compile and get warnings/errors (CS* and CA* rules) |
 | `roslyn_apply_code_fix` | Apply Roslyn's suggested fix for a single diagnostic |
 | `roslyn_batch_apply_code_fixes` | Batch apply fixes for all diagnostics of a specific type |
+| `roslyn_remove_unnecessary_usings` | Remove unnecessary using directives (CS8019) from files |
 | `roslyn_rename_symbol` | Rename a symbol across the entire solution with all references |
 | `roslyn_extract_method` | Extract code block into new method with automatic parameter/return detection |
 | `roslyn_get_projects_in_build_order` | Get solution structure and dependencies |

--- a/RoslynMcpServer.Graph/GraphDatabase.Files.cs
+++ b/RoslynMcpServer.Graph/GraphDatabase.Files.cs
@@ -1,6 +1,5 @@
 using Dapper;
 using System.Security.Cryptography;
-using System.Text;
 
 namespace RoslynMcpServer.Graph;
 

--- a/Services/SymbolSearchService.cs
+++ b/Services/SymbolSearchService.cs
@@ -66,7 +66,8 @@ public class SymbolSearchService
 
         return new FindSymbolResult
         {
-            Success = true, SolutionPath = solutionPath,
+            Success = true,
+            SolutionPath = solutionPath,
             Pattern = pattern,
             TotalFound = symbols.Count(),
             Symbols = results

--- a/src/HookTokenService.cs
+++ b/src/HookTokenService.cs
@@ -1,7 +1,6 @@
 using System.Collections.Concurrent;
 using System.Security.Cryptography;
 using System.Text;
-using System.Text.Json;
 
 namespace RoslynMcpServer;
 

--- a/src/RoslynTools.FindSymbol.cs
+++ b/src/RoslynTools.FindSymbol.cs
@@ -1,6 +1,4 @@
 using System.Text.Json;
-using System.Text.Json.Nodes;
-using RoslynMcpServer.Graph;
 
 namespace RoslynMcpServer;
 

--- a/src/RoslynTools.Implementations.cs
+++ b/src/RoslynTools.Implementations.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using System.Text.Json.Nodes;
 
 namespace RoslynMcpServer;
 

--- a/src/RoslynTools.Knowledge.cs
+++ b/src/RoslynTools.Knowledge.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using RoslynMcpServer.Graph;
 
 namespace RoslynMcpServer;

--- a/src/RoslynTools.MethodBody.cs
+++ b/src/RoslynTools.MethodBody.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using RoslynMcpServer.Graph;
 
 namespace RoslynMcpServer;
 

--- a/src/RoslynTools.References.cs
+++ b/src/RoslynTools.References.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using System.Text.Json.Nodes;
 
 namespace RoslynMcpServer;
 

--- a/src/RoslynTools.RemoveUsings.cs
+++ b/src/RoslynTools.RemoveUsings.cs
@@ -1,0 +1,86 @@
+using System.Text.Json;
+
+namespace RoslynMcpServer;
+
+public static partial class RoslynTools
+{
+    /// <summary>
+    /// Removes unnecessary using directives from files in the solution.
+    /// </summary>
+    private static void RegisterRemoveUnnecessaryUsingsTool(McpServer server)
+    {
+        server.RegisterTool(
+            "roslyn_remove_unnecessary_usings",
+            new ToolDefinition
+            {
+                Description = "Removes unnecessary using directives (CS8019) from C# files. This is a dedicated tool because the standard code fix provider for CS8019 requires IDE services that aren't available in batch mode. Skips generated files in obj/ folders.",
+                InputSchema = new
+                {
+                    type = "object",
+                    properties = new
+                    {
+                        solutionPath = new
+                        {
+                            type = "string",
+                            description = "Absolute path to the .sln or .slnx solution file"
+                        },
+                        projectFilter = new
+                        {
+                            type = "string",
+                            description = "Optional: filter by project name (partial match)"
+                        },
+                        fileFilter = new
+                        {
+                            type = "string",
+                            description = "Optional: filter by file name or path (partial match)"
+                        },
+                        preview = new
+                        {
+                            type = "boolean",
+                            description = "If true, shows what would be removed without making changes. Default: false"
+                        }
+                    },
+                    required = new[] { "solutionPath" }
+                },
+                Annotations = new ToolAnnotations
+                {
+                    ReadOnlyHint = false,
+                    IdempotentHint = true
+                }
+            },
+            async args =>
+            {
+                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var projectFilter = args?["projectFilter"]?.GetValue<string>();
+                var fileFilter = args?["fileFilter"]?.GetValue<string>();
+                var preview = args?["preview"]?.GetValue<bool>() ?? false;
+
+                if (string.IsNullOrWhiteSpace(solutionPath))
+                {
+                    return new
+                    {
+                        content = new[]
+                        {
+                            new { type = "text", text = "Error: solutionPath is required" }
+                        },
+                        isError = true
+                    };
+                }
+
+                var result = await SolutionAnalyzerService.RemoveUnnecessaryUsingsAsync(
+                    solutionPath,
+                    projectFilter,
+                    fileFilter,
+                    preview);
+
+                return new
+                {
+                    content = new[]
+                    {
+                        new { type = "text", text = JsonSerializer.Serialize(result, JsonOptions) }
+                    },
+                    isError = !result.Success
+                };
+            });
+    }
+}

--- a/src/RoslynTools.TypeMembers.cs
+++ b/src/RoslynTools.TypeMembers.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using RoslynMcpServer.Graph;
 
 namespace RoslynMcpServer;
 

--- a/src/RoslynTools.cs
+++ b/src/RoslynTools.cs
@@ -1,5 +1,4 @@
 using System.Text.Json;
-using System.Text.Json.Nodes;
 
 namespace RoslynMcpServer;
 
@@ -39,6 +38,7 @@ public static partial class RoslynTools
         RegisterDeleteMemberTool(server);
         RegisterApplyCodeFixTool(server);
         RegisterBatchApplyCodeFix(server);
+        RegisterRemoveUnnecessaryUsingsTool(server);
         RegisterRenameSymbolTool(server);
         RegisterExtractMethodTool(server);
         RegisterGraphStatusTool(server);

--- a/src/SolutionAnalyzerService.Callers.cs
+++ b/src/SolutionAnalyzerService.Callers.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FindSymbols;
-using Microsoft.CodeAnalysis.MSBuild;
 
 namespace RoslynMcpServer;
 

--- a/src/SolutionAnalyzerService.ExtractMethod.cs
+++ b/src/SolutionAnalyzerService.ExtractMethod.cs
@@ -1,9 +1,7 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.FlowAnalysis;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.Operations;
 
 namespace RoslynMcpServer;
 

--- a/src/SolutionAnalyzerService.Implementations.cs
+++ b/src/SolutionAnalyzerService.Implementations.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FindSymbols;
-using Microsoft.CodeAnalysis.MSBuild;
 
 namespace RoslynMcpServer;
 

--- a/src/SolutionAnalyzerService.MethodBody.cs
+++ b/src/SolutionAnalyzerService.MethodBody.cs
@@ -1,7 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;
-using Microsoft.CodeAnalysis.MSBuild;
 
 namespace RoslynMcpServer;
 

--- a/src/SolutionAnalyzerService.References.cs
+++ b/src/SolutionAnalyzerService.References.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FindSymbols;
-using Microsoft.CodeAnalysis.MSBuild;
 
 namespace RoslynMcpServer;
 

--- a/src/SolutionAnalyzerService.RemoveUsings.cs
+++ b/src/SolutionAnalyzerService.RemoveUsings.cs
@@ -1,0 +1,203 @@
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace RoslynMcpServer;
+
+public partial class SolutionAnalyzerService
+{
+    /// <summary>
+    /// Removes unnecessary using directives from files in the solution.
+    /// Uses CS8019 diagnostics to identify which usings are unnecessary.
+    /// </summary>
+    public static async Task<RemoveUnnecessaryUsingsResult> RemoveUnnecessaryUsingsAsync(
+        string solutionPath,
+        string? projectFilter = null,
+        string? fileFilter = null,
+        bool preview = false)
+    {
+        EnsureMSBuildRegistered();
+
+        if (!File.Exists(solutionPath))
+        {
+            return new RemoveUnnecessaryUsingsResult
+            {
+                Success = false,
+                Error = $"Solution file not found: {solutionPath}"
+            };
+        }
+
+        using var workspace = CreateWorkspace();
+
+        try
+        {
+            Console.Error.WriteLine($"Loading solution: {solutionPath}");
+            var solution = await workspace.OpenSolutionAsync(solutionPath);
+
+            var filesModified = new List<string>();
+            var usingsRemoved = new List<RemovedUsingInfo>();
+            int totalUsingsRemoved = 0;
+
+            foreach (var project in solution.Projects)
+            {
+                if (!string.IsNullOrEmpty(projectFilter) &&
+                    !project.Name.Contains(projectFilter, StringComparison.OrdinalIgnoreCase))
+                    continue;
+
+                var compilation = await project.GetCompilationAsync();
+                if (compilation == null) continue;
+
+                // Get CS8019 diagnostics (unnecessary using directive)
+                var cs8019Diagnostics = compilation.GetDiagnostics()
+                    .Where(d => d.Id == "CS8019" && d.Location.IsInSource)
+                    .ToList();
+
+                // Group by file
+                var diagnosticsByFile = cs8019Diagnostics
+                    .GroupBy(d => d.Location.SourceTree?.FilePath)
+                    .Where(g => g.Key != null);
+
+                foreach (var fileGroup in diagnosticsByFile)
+                {
+                    var filePath = fileGroup.Key!;
+
+                    // Apply file filter
+                    if (!string.IsNullOrEmpty(fileFilter))
+                    {
+                        var fileName = Path.GetFileName(filePath);
+                        if (!fileName.Contains(fileFilter, StringComparison.OrdinalIgnoreCase) &&
+                            !filePath.Contains(fileFilter, StringComparison.OrdinalIgnoreCase))
+                            continue;
+                    }
+
+                    // Skip generated files (obj folder)
+                    if (filePath.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}") ||
+                        filePath.Contains($"{Path.AltDirectorySeparatorChar}obj{Path.AltDirectorySeparatorChar}"))
+                        continue;
+
+                    var syntaxTree = compilation.SyntaxTrees
+                        .FirstOrDefault(t => t.FilePath == filePath);
+                    if (syntaxTree == null) continue;
+
+                    var root = await syntaxTree.GetRootAsync();
+                    var diagnosticSpans = fileGroup
+                        .Select(d => d.Location.SourceSpan)
+                        .ToHashSet();
+
+                    // Find all using directives that have CS8019 diagnostics
+                    var usingsToRemove = root.DescendantNodes()
+                        .OfType<UsingDirectiveSyntax>()
+                        .Where(u => diagnosticSpans.Any(span =>
+                            u.Span.Contains(span) || span.Contains(u.Span) ||
+                            u.Span.IntersectsWith(span)))
+                        .ToList();
+
+                    if (usingsToRemove.Count == 0) continue;
+
+                    // Track what we're removing
+                    foreach (var usingDirective in usingsToRemove)
+                    {
+                        usingsRemoved.Add(new RemovedUsingInfo
+                        {
+                            FilePath = filePath,
+                            UsingDirective = usingDirective.Name?.ToString() ?? usingDirective.ToString().Trim(),
+                            Line = usingDirective.GetLocation().GetLineSpan().StartLinePosition.Line + 1
+                        });
+                    }
+
+                    totalUsingsRemoved += usingsToRemove.Count;
+
+                    if (!preview)
+                    {
+                        // Remove the using directives
+                        var newRoot = root.RemoveNodes(usingsToRemove, SyntaxRemoveOptions.KeepLeadingTrivia);
+                        if (newRoot != null)
+                        {
+                            // Clean up any double blank lines that may result
+                            var newSource = newRoot.ToFullString();
+                            newSource = CleanupExtraBlankLines(newSource);
+
+                            await File.WriteAllTextAsync(filePath, newSource);
+                            filesModified.Add(filePath);
+                            Console.Error.WriteLine($"Removed {usingsToRemove.Count} usings from: {filePath}");
+                        }
+                    }
+                    else
+                    {
+                        filesModified.Add(filePath);
+                    }
+                }
+            }
+
+            return new RemoveUnnecessaryUsingsResult
+            {
+                Success = true,
+                SolutionPath = solutionPath,
+                TotalUsingsRemoved = totalUsingsRemoved,
+                FilesModified = filesModified.Count,
+                ModifiedFiles = filesModified,
+                RemovedUsings = usingsRemoved.Count <= 100 ? usingsRemoved : null,
+                IsPreview = preview
+            };
+        }
+        catch (Exception ex)
+        {
+            return new RemoveUnnecessaryUsingsResult
+            {
+                Success = false,
+                Error = $"Failed to remove unnecessary usings: {ex.Message}"
+            };
+        }
+    }
+
+    /// <summary>
+    /// Removes consecutive blank lines, keeping at most one blank line.
+    /// </summary>
+    private static string CleanupExtraBlankLines(string source)
+    {
+        var lines = source.Split('\n');
+        var result = new List<string>();
+        bool previousWasBlank = false;
+
+        foreach (var line in lines)
+        {
+            bool isBlank = string.IsNullOrWhiteSpace(line);
+
+            if (isBlank && previousWasBlank)
+            {
+                // Skip consecutive blank lines
+                continue;
+            }
+
+            result.Add(line);
+            previousWasBlank = isBlank;
+        }
+
+        return string.Join('\n', result);
+    }
+}
+
+/// <summary>
+/// Result of removing unnecessary usings.
+/// </summary>
+public class RemoveUnnecessaryUsingsResult
+{
+    public bool Success { get; init; }
+    public string? Error { get; init; }
+    public string? SolutionPath { get; init; }
+    public int TotalUsingsRemoved { get; init; }
+    public int FilesModified { get; init; }
+    public List<string> ModifiedFiles { get; init; } = [];
+    public List<RemovedUsingInfo>? RemovedUsings { get; init; }
+    public bool IsPreview { get; init; }
+}
+
+/// <summary>
+/// Information about a removed using directive.
+/// </summary>
+public class RemovedUsingInfo
+{
+    public required string FilePath { get; init; }
+    public required string UsingDirective { get; init; }
+    public int Line { get; init; }
+}

--- a/src/SolutionAnalyzerService.Rename.cs
+++ b/src/SolutionAnalyzerService.Rename.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FindSymbols;
-using Microsoft.CodeAnalysis.MSBuild;
 using Microsoft.CodeAnalysis.Rename;
 
 namespace RoslynMcpServer;

--- a/src/SolutionAnalyzerService.TypeMembers.cs
+++ b/src/SolutionAnalyzerService.TypeMembers.cs
@@ -1,6 +1,5 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.FindSymbols;
-using Microsoft.CodeAnalysis.MSBuild;
 
 namespace RoslynMcpServer;
 

--- a/src/SolutionAnalyzerService.UpdateMethod.cs
+++ b/src/SolutionAnalyzerService.UpdateMethod.cs
@@ -3,7 +3,6 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.FindSymbols;
 using Microsoft.CodeAnalysis.Formatting;
-using Microsoft.CodeAnalysis.MSBuild;
 
 namespace RoslynMcpServer;
 


### PR DESCRIPTION
## Summary
- Add dedicated `roslyn_remove_unnecessary_usings` tool to remove CS8019 (unnecessary using) directives
- Uses Roslyn-recommended approach: get diagnostics then remove syntax nodes
- Skips generated files in obj/ folders automatically
- Supports preview mode to see what will be removed
- Removed 19 unnecessary usings from 17 source files

## Technical Background
CS8019 has no batch code fix provider in Roslyn (by design). The `RemoveUnnecessaryImportsService` is internal and not exposed as public API ([dotnet/roslyn#1576](https://github.com/dotnet/roslyn/issues/1576)). This tool implements the officially recommended workaround from Roslyn developers.

## Test plan
- [x] Build succeeds with 0 warnings, 0 errors
- [x] All 109 tests pass
- [x] Preview mode shows correct usings to remove
- [x] Apply mode removes usings and code still compiles
- [x] Skips obj/ folders correctly

Fixes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)