### PR TITLE
Feature: Auto-detect solution path - remove solutionPath from all tools

### DIFF
--- a/Instructions/Topics/tools.md
+++ b/Instructions/Topics/tools.md
@@ -62,9 +62,7 @@ You have access to Roslyn MCP tools for C# code analysis. These tools provide se
 | Tool | Purpose |
 |------|---------|
 | `roslyn_get_template` | Get CLAUDE.md template for projects |
-| `roslyn_get_instructions` | Get topic-specific development instructions (see note below) |
-
-**Note:** For `plan`, `git`, and `tools` topics, tokens are written to `.roslyn-mcp/` folder for hook validation.
+| `roslyn_get_instructions` | Get topic-specific development instructions |
 
 ### Knowledge Base (Semantic Search)
 
@@ -155,18 +153,18 @@ Creates `MyApp.Core/Services/UserService.cs` with namespace `MyApp.Core.Services
 3. Assess impact before changing signature
 
 ### Impact analysis (large codebase)
-1. `roslyn_graph_analyze(solutionPath)` → build/update call graph (first time)
+1. `roslyn_graph_analyze()` → build/update call graph (first time)
 2. `roslyn_query_graph(symbolName, direction: "callers", maxDepth: 3)` → find all callers recursively
 3. Much faster than `roslyn_get_callers` for repeated queries
 
 ### Impact analysis before refactoring (blast radius)
-1. `roslyn_graph_analyze(solutionPath)` → build call graph if needed
+1. `roslyn_graph_analyze()` → build call graph if needed
 2. `roslyn_graph_impact(symbolName)` → see all affected files and methods
 3. Results grouped by file for easy review
 
 ### Finding dead code
-1. `roslyn_graph_analyze(solutionPath)` → build call graph
-2. `roslyn_find_dead_code(solutionPath)` → find unused methods/properties
+1. `roslyn_graph_analyze()` → build call graph
+2. `roslyn_find_dead_code()` → find unused methods/properties
 3. Review results - automatically excludes:
    - Entry points (Main, RunAsync, event handlers)
    - Properties with attributes (likely serialization)
@@ -177,7 +175,7 @@ Creates `MyApp.Core/Services/UserService.cs` with namespace `MyApp.Core.Services
    - `excludeFilePatterns: ["Models/"]` for additional path-based exclusion
 
 ### Cleaning up dead code
-1. `roslyn_find_dead_code(solutionPath)` → identify unused members
+1. `roslyn_find_dead_code()` → identify unused members
 2. Review each result to confirm it's truly dead (not reflection-based)
 3. `roslyn_delete_member(typeName, memberName)` → remove confirmed dead code
 4. Includes attributes and XML docs in deletion
@@ -188,8 +186,8 @@ Creates `MyApp.Core/Services/UserService.cs` with namespace `MyApp.Core.Services
 3. `roslyn_batch_apply_code_fixes(diagnosticId: "CS8618")` → auto-fix
 
 ### Removing unnecessary usings (CS8019)
-1. `roslyn_remove_unnecessary_usings(solutionPath, preview: true)` → preview what will be removed
-2. `roslyn_remove_unnecessary_usings(solutionPath)` → remove all unnecessary usings
+1. `roslyn_remove_unnecessary_usings(preview: true)` → preview what will be removed
+2. `roslyn_remove_unnecessary_usings()` → remove all unnecessary usings
 3. Automatically skips generated files in obj/ folders
 
 **Note:** CS8019 (unnecessary using) requires this dedicated tool because Roslyn's code fix provider for it needs IDE services not available in batch mode.

--- a/RoslynMcpServer.Graph/GraphAnalyzer.cs
+++ b/RoslynMcpServer.Graph/GraphAnalyzer.cs
@@ -366,6 +366,14 @@ public sealed class GraphAnalyzer
 
     private async Task<long?> FindOrCreateTargetSymbolAsync(ISymbol symbol, long solutionId)
     {
+        // Check if symbol has source code in the solution
+        var location = symbol.Locations.FirstOrDefault();
+        var filePath = location?.SourceTree?.FilePath;
+
+        // Skip external symbols - no source file means BCL/NuGet/external
+        if (string.IsNullOrEmpty(filePath))
+            return null;
+
         var qualifiedName = GetQualifiedName(symbol);
 
         // Check cache first
@@ -380,9 +388,7 @@ public sealed class GraphAnalyzer
             return existing.Id;
         }
 
-        // Create placeholder for external symbols
-        var location = symbol.Locations.FirstOrDefault();
-        var filePath = location?.SourceTree?.FilePath ?? "external";
+        // Create new symbol record for solution code
         var line = location?.GetLineSpan().StartLinePosition.Line + 1 ?? 0;
         var column = location?.GetLineSpan().StartLinePosition.Character + 1 ?? 0;
 

--- a/src/RoslynTools.AddMember.cs
+++ b/src/RoslynTools.AddMember.cs
@@ -172,4 +172,14 @@ public static partial class RoslynTools
             return "created";
         }
     }
+
+
+    private static (string? Path, object? Error) GetSolutionPathOrError()
+    {
+        if (string.IsNullOrEmpty(_solutionPath))
+        {
+            return (null, CreateErrorResponse("No solution detected. Run MCP server from solution directory."));
+        }
+        return (_solutionPath, null);
+    }
 }

--- a/src/RoslynTools.AddType.cs
+++ b/src/RoslynTools.AddType.cs
@@ -7,7 +7,7 @@ public static partial class RoslynTools
 {
     private static readonly string[] definitionArray6 = ["class", "interface", "struct", "record", "enum"];
     private static readonly string[] definitionArray7 = ["public", "internal", "private", "protected"];
-    private static readonly string[] definitionArray8 = ["solutionPath", "projectName", "typeName"];
+    private static readonly string[] definitionArray8 = ["projectName", "typeName"];
 
     /// <summary>
     /// Creates a new type (class, interface, struct, record, enum) in a project.
@@ -98,10 +98,10 @@ public static partial class RoslynTools
     /// </summary>
     private static async Task<object> HandleAddTypeAsync(JsonObject? args)
     {
-        if (!TryGetRequiredString(args, "solutionPath", out var solutionPath, out var error))
-            return error!;
+        var (solutionPath, solutionError) = GetSolutionPathOrError();
+        if (solutionError != null) return solutionError;
 
-        if (!TryGetRequiredString(args, "projectName", out var projectName, out error))
+        if (!TryGetRequiredString(args, "projectName", out var projectName, out var error))
             return error!;
 
         if (!TryGetRequiredString(args, "typeName", out var typeName, out error))
@@ -117,7 +117,7 @@ public static partial class RoslynTools
         var isStatic = GetOptionalBool(args, "isStatic", false);
 
         var result = await SolutionAnalyzerService.AddTypeAsync(
-            solutionPath, projectName, typeName, typeKind, ns, folder,
+            solutionPath!, projectName, typeName, typeKind, ns, folder,
             accessibility, baseTypes, isPartial, isSealed, isStatic);
 
         return CreateSuccessResponse(result, !result.Success);

--- a/src/RoslynTools.BatchCodeFix.cs
+++ b/src/RoslynTools.BatchCodeFix.cs
@@ -4,7 +4,7 @@ namespace RoslynMcpServer;
 
 public static partial class RoslynTools
 {
-    private static readonly string[] definitionArray9 = new[] { "solutionPath", "diagnosticId" };
+    private static readonly string[] definitionArray9 = new[] { "diagnosticId" };
 
     private static void RegisterBatchApplyCodeFix(McpServer server)
     {
@@ -63,24 +63,14 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
+
                 var diagnosticId = args?["diagnosticId"]?.GetValue<string>();
                 var projectFilter = args?["projectFilter"]?.GetValue<string>();
                 var fileFilter = args?["fileFilter"]?.GetValue<string>();
                 var maxFixes = args?["maxFixes"]?.GetValue<int>() ?? 100;
                 var preview = args?["preview"]?.GetValue<bool>() ?? false;
-
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                {
-                    return new
-                    {
-                        content = new[]
-                        {
-                            new { type = "text", text = "Error: solutionPath is required" }
-                        },
-                        isError = true
-                    };
-                }
 
                 if (string.IsNullOrWhiteSpace(diagnosticId))
                 {
@@ -94,9 +84,8 @@ public static partial class RoslynTools
                     };
                 }
 
-                var service = new SolutionAnalyzerService();
                 var result = await SolutionAnalyzerService.BatchApplyCodeFixAsync(
-                    solutionPath, diagnosticId, projectFilter, fileFilter, maxFixes, preview);
+                    solutionPath!, diagnosticId, projectFilter, fileFilter, maxFixes, preview);
 
                 return new
                 {

--- a/src/RoslynTools.Callers.cs
+++ b/src/RoslynTools.Callers.cs
@@ -6,7 +6,7 @@ namespace RoslynMcpServer;
 
 public static partial class RoslynTools
 {
-    private static readonly string[] definitionArray1 = ["solutionPath", "filePath", "line", "column"];
+    private static readonly string[] definitionArray1 = ["filePath", "line", "column"];
 
     /// <summary>
     /// Finds all callers of a method at a given position.
@@ -70,7 +70,7 @@ public static partial class RoslynTools
                             description = "Filter by file path. Supports wildcards (*). Example: '*Service.cs'"
                         }
                     },
-                    required = definitionArray100
+                    required = definitionArray1
                 },
                 Annotations = new ToolAnnotations
                 {
@@ -86,10 +86,10 @@ public static partial class RoslynTools
     /// </summary>
     private static async Task<object> HandleGetCallersAsync(JsonObject? args)
     {
-        if (!TryGetRequiredString(args, "solutionPath", out var solutionPath, out var error))
-            return error!;
+        var (solutionPath, solutionError) = GetSolutionPathOrError();
+        if (solutionError != null) return solutionError;
 
-        if (!TryGetRequiredString(args, "filePath", out var filePath, out error))
+        if (!TryGetRequiredString(args, "filePath", out var filePath, out var error))
             return error!;
 
         if (!TryGetRequiredInt(args, "line", 1, out var line, out error))
@@ -105,7 +105,7 @@ public static partial class RoslynTools
 
         // Try graph cache first
         var graphResult = await TryGetCallersFromGraphAsync(
-            solutionPath, filePath, line, column, maxResults, offset, projectFilter, fileFilter);
+            solutionPath!, filePath, line, column, maxResults, offset, projectFilter, fileFilter);
 
         if (graphResult != null)
         {
@@ -114,7 +114,7 @@ public static partial class RoslynTools
 
         // Fall back to live analysis
         var result = await SolutionAnalyzerService.GetCallersAsync(
-            solutionPath, filePath, line, column, maxResults, offset, projectFilter, fileFilter);
+            solutionPath!, filePath, line, column, maxResults, offset, projectFilter, fileFilter);
 
         // Add source indicator for live analysis
         var liveResult = new GetCallersResult

--- a/src/RoslynTools.CodeFix.cs
+++ b/src/RoslynTools.CodeFix.cs
@@ -4,7 +4,7 @@ namespace RoslynMcpServer;
 
 public static partial class RoslynTools
 {
-    private static readonly string[] definitionArray10 = new[] { "solutionPath", "filePath", "line", "column" };
+    private static readonly string[] definitionArray10 = new[] { "filePath", "line", "column" };
 
     /// <summary>
     /// Registers the roslyn_apply_code_fix tool.
@@ -75,25 +75,15 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
+
                 var filePath = args?["filePath"]?.GetValue<string>();
                 var line = args?["line"]?.GetValue<int>() ?? 0;
                 var column = args?["column"]?.GetValue<int>() ?? 0;
                 var diagnosticId = args?["diagnosticId"]?.GetValue<string>();
                 var fixIndex = args?["fixIndex"]?.GetValue<int?>();
                 var preview = args?["preview"]?.GetValue<bool>() ?? false;
-
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                {
-                    return new
-                    {
-                        content = new[]
-                        {
-                            new { type = "text", text = "Error: solutionPath is required" }
-                        },
-                        isError = true
-                    };
-                }
 
                 if (string.IsNullOrWhiteSpace(filePath))
                 {
@@ -132,7 +122,7 @@ public static partial class RoslynTools
                 }
 
                 var result = await SolutionAnalyzerService.ApplyCodeFixAsync(
-                    solutionPath,
+                    solutionPath!,
                     filePath,
                     line,
                     column,

--- a/src/RoslynTools.DeleteMember.cs
+++ b/src/RoslynTools.DeleteMember.cs
@@ -5,7 +5,7 @@ namespace RoslynMcpServer;
 public static partial class RoslynTools
 {
     private static readonly string[] definitionArray13 = new[] { "method", "property", "field" };
-    private static readonly string[] definitionArray14 = new[] { "solutionPath", "typeName", "memberName" };
+    private static readonly string[] definitionArray14 = new[] { "typeName", "memberName" };
 
     /// <summary>
     /// Deletes a member (method, property, field) from a type.
@@ -60,23 +60,13 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
+
                 var typeName = args?["typeName"]?.GetValue<string>();
                 var memberName = args?["memberName"]?.GetValue<string>();
                 var memberKind = args?["memberKind"]?.GetValue<string>();
                 var parameterTypes = args?["parameterTypes"]?.GetValue<string>();
-
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                {
-                    return new
-                    {
-                        content = new[]
-                        {
-                            new { type = "text", text = "Error: solutionPath is required" }
-                        },
-                        isError = true
-                    };
-                }
 
                 if (string.IsNullOrWhiteSpace(typeName))
                 {
@@ -103,7 +93,7 @@ public static partial class RoslynTools
                 }
 
                 var result = await SolutionAnalyzerService.DeleteMemberAsync(
-                    solutionPath,
+                    solutionPath!,
                     typeName,
                     memberName,
                     memberKind,

--- a/src/RoslynTools.Diagnostics.cs
+++ b/src/RoslynTools.Diagnostics.cs
@@ -5,7 +5,7 @@ namespace RoslynMcpServer;
 public static partial class RoslynTools
 {
     private static readonly string[] definitionArray15 = new[] { "all", "error", "warning", "info" };
-    private static readonly string[] definitionArray16 = new[] { "solutionPath" };
+    private static readonly string[] definitionArray16 = Array.Empty<string>();
 
     /// <summary>
     /// Gets compilation diagnostics (warnings/errors) from a solution.
@@ -67,19 +67,8 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
-
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                {
-                    return new
-                    {
-                        content = new[]
-                        {
-                            new { type = "text", text = "Error: solutionPath is required" }
-                        },
-                        isError = true
-                    };
-                }
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
 
                 var diagnosticId = args?["diagnosticId"]?.GetValue<string>();
                 var severityFilter = args?["severityFilter"]?.GetValue<string>();
@@ -88,7 +77,7 @@ public static partial class RoslynTools
                 var offset = args?["offset"]?.GetValue<int>() ?? 0;
 
                 var result = await SolutionAnalyzerService.GetDiagnosticsAsync(
-                    solutionPath,
+                    solutionPath!,
                     diagnosticId,
                     severityFilter,
                     projectFilter,

--- a/src/RoslynTools.ExtractMethod.cs
+++ b/src/RoslynTools.ExtractMethod.cs
@@ -5,7 +5,7 @@ namespace RoslynMcpServer;
 public static partial class RoslynTools
 {
     private static readonly string[] definitionArray17 = new[] { "private", "internal", "protected", "public" };
-    private static readonly string[] definitionArray18 = new[] { "solutionPath", "filePath", "startLine", "endLine", "methodName" };
+    private static readonly string[] definitionArray18 = new[] { "filePath", "startLine", "endLine", "methodName" };
 
     /// <summary>
     /// Extracts a code block into a new method using Roslyn data flow analysis.
@@ -66,24 +66,14 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
+
                 var filePath = args?["filePath"]?.GetValue<string>();
                 var startLine = args?["startLine"]?.GetValue<int>() ?? 0;
                 var endLine = args?["endLine"]?.GetValue<int>() ?? 0;
                 var methodName = args?["methodName"]?.GetValue<string>();
                 var accessibility = args?["accessibility"]?.GetValue<string>();
-
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                {
-                    return new
-                    {
-                        content = new[]
-                        {
-                            new { type = "text", text = "Error: solutionPath is required" }
-                        },
-                        isError = true
-                    };
-                }
 
                 if (string.IsNullOrWhiteSpace(filePath))
                 {
@@ -134,7 +124,7 @@ public static partial class RoslynTools
                 }
 
                 var result = await SolutionAnalyzerService.ExtractMethodAsync(
-                    solutionPath,
+                    solutionPath!,
                     filePath,
                     startLine,
                     endLine,

--- a/src/RoslynTools.FindSymbol.cs
+++ b/src/RoslynTools.FindSymbol.cs
@@ -7,7 +7,7 @@ public static partial class RoslynTools
 {
     private static readonly string[] definitionArray19 = ["all", "type", "member", "namespace", "typeAndMember"];
     private static readonly string[] definitionArray20 = ["exact", "exactIgnoreCase", "contains", "prefix", "suffix"];
-    private static readonly string[] definitionArray21 = ["solutionPath", "pattern"];
+    private static readonly string[] definitionArray21 = ["pattern"];
 
     /// <summary>
     /// Finds symbols in a solution by name pattern.
@@ -75,8 +75,8 @@ public static partial class RoslynTools
     /// </summary>
     private static async Task<object> HandleFindSymbolAsync(JsonObject? args)
     {
-        if (!TryGetRequiredString(args, "solutionPath", out var solutionPath, out var error))
-            return error!;
+        var (solutionPath, error) = GetSolutionPathOrError();
+        if (error != null) return error;
 
         if (!TryGetRequiredString(args, "pattern", out var pattern, out error))
             return error!;
@@ -87,9 +87,9 @@ public static partial class RoslynTools
         var compact = GetOptionalBool(args, "compact", true);
 
         var result = await _analyzerService!.SearchSymbolsAsync(
-            solutionPath, pattern, symbolKind, matchType, maxResults, compact);
+            solutionPath!, pattern, symbolKind, matchType, maxResults, compact);
 
-        var response = await BuildFindSymbolResponseAsync(solutionPath, result);
+        var response = await BuildFindSymbolResponseAsync(solutionPath!, result);
         return CreateSuccessResponse(response, !result.Success);
     }
 

--- a/src/RoslynTools.Graph.cs
+++ b/src/RoslynTools.Graph.cs
@@ -39,19 +39,10 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
 
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                {
-                    return CreateErrorResponse("Error: solutionPath is required");
-                }
-
-                if (!File.Exists(solutionPath))
-                {
-                    return CreateErrorResponse($"Error: Solution file not found: {solutionPath}");
-                }
-
-                var result = await GetGraphStatusAsync(solutionPath);
+                var result = await GetGraphStatusAsync(solutionPath!);
                 return CreateJsonResponse(result);
             });
     }
@@ -97,21 +88,13 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
+
                 var incremental = args?["incremental"]?.GetValue<bool>() ?? true;
                 var projectFilter = args?["projectFilter"]?.GetValue<string>();
 
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                {
-                    return CreateErrorResponse("Error: solutionPath is required");
-                }
-
-                if (!File.Exists(solutionPath))
-                {
-                    return CreateErrorResponse($"Error: Solution file not found: {solutionPath}");
-                }
-
-                var result = await AnalyzeGraphAsync(solutionPath, incremental, projectFilter);
+                var result = await AnalyzeGraphAsync(solutionPath!, incremental, projectFilter);
                 return CreateJsonResponse(result, !result.Success);
             });
     }
@@ -165,22 +148,19 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
+
                 var symbolName = args?["symbolName"]?.GetValue<string>();
                 var direction = args?["direction"]?.GetValue<string>() ?? "both";
                 var maxDepth = args?["maxDepth"]?.GetValue<int>() ?? 3;
-
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                {
-                    return CreateErrorResponse("Error: solutionPath is required");
-                }
 
                 if (string.IsNullOrWhiteSpace(symbolName))
                 {
                     return CreateErrorResponse("Error: symbolName is required");
                 }
 
-                var result = await QueryGraphAsync(solutionPath, symbolName, direction, maxDepth);
+                var result = await QueryGraphAsync(solutionPath!, symbolName, direction, maxDepth);
                 return CreateJsonResponse(result, !result.Success);
             });
     }
@@ -287,10 +267,10 @@ public static partial class RoslynTools
         };
     }
 
-    private static readonly string[] definitionArray25 = new[] { "solutionPath", "symbolName" };
+    private static readonly string[] definitionArray25 = new[] { "symbolName" };
     private static readonly string[] definitionArray24 = new[] { "callers", "callees", "both" };
-    private static readonly string[] definitionArray23 = new[] { "solutionPath" };
-    private static readonly string[] definitionArray22 = new[] { "solutionPath" };
+    private static readonly string[] definitionArray23 = Array.Empty<string>();
+    private static readonly string[] definitionArray22 = Array.Empty<string>();
 
     private static async Task<GraphQueryResult> QueryGraphAsync(
         string solutionPath, string symbolName, string direction, int maxDepth)

--- a/src/RoslynTools.Graph.cs
+++ b/src/RoslynTools.Graph.cs
@@ -318,6 +318,9 @@ public static partial class RoslynTools
             };
         }
 
+        // Get solution directory for relative paths (Issue #115)
+        var solutionDir = Path.GetDirectoryName(solutionPath) ?? "";
+
         // Use FindSymbolAsync for partial name matching (Issue #33)
         var searchResult = await db.FindSymbolAsync(solution.Id, symbolName);
 
@@ -389,7 +392,7 @@ public static partial class RoslynTools
         var result = new GraphQueryResult
         {
             Success = true,
-            Symbol = ToGraphSymbolEntry(symbol),
+            Symbol = ToGraphSymbolEntry(symbol, solutionDir),
             StaleFilesRefreshed = refreshedFiles.Count,
             RefreshedFiles = refreshedFiles.Count > 0 ? refreshedFiles : null
         };
@@ -399,7 +402,7 @@ public static partial class RoslynTools
             var callers = refreshedFiles.Count > 0
                 ? await db.GetRecursiveCallersAsync(symbol.Id, maxDepth)
                 : preliminaryCallers;
-            result.Callers = callers.Select(ToGraphSymbolEntry).ToList();
+            result.Callers = callers.Select(s => ToGraphSymbolEntry(s, solutionDir)).ToList();
         }
 
         if (direction is "callees" or "both")
@@ -407,7 +410,7 @@ public static partial class RoslynTools
             var callees = refreshedFiles.Count > 0
                 ? await db.GetRecursiveCalleesAsync(symbol.Id, maxDepth)
                 : preliminaryCallees;
-            result.Callees = callees.Select(ToGraphSymbolEntry).ToList();
+            result.Callees = callees.Select(s => ToGraphSymbolEntry(s, solutionDir)).ToList();
         }
 
         return result;
@@ -416,12 +419,12 @@ public static partial class RoslynTools
     /// <summary>
     /// Converts a SymbolRecord to a GraphSymbolEntry.
     /// </summary>
-    private static GraphSymbolEntry ToGraphSymbolEntry(SymbolRecord symbol) => new()
+    private static GraphSymbolEntry ToGraphSymbolEntry(SymbolRecord symbol, string solutionDir) => new()
     {
         Name = symbol.Name,
         QualifiedName = symbol.QualifiedName,
         Kind = symbol.Kind.ToString(),
-        FilePath = symbol.FilePath,
+        FilePath = GetRelativePath(symbol.FilePath, solutionDir),
         Line = symbol.Line
     };
 

--- a/src/RoslynTools.GraphImpact.cs
+++ b/src/RoslynTools.GraphImpact.cs
@@ -56,21 +56,17 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
+
                 var symbolName = args?["symbolName"]?.GetValue<string>();
                 var maxDepth = args?["maxDepth"]?.GetValue<int>() ?? 10;
                 var includeTests = args?["includeTests"]?.GetValue<bool>() ?? true;
 
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                    return CreateToolError("Error: solutionPath is required");
-
                 if (string.IsNullOrWhiteSpace(symbolName))
                     return CreateToolError("Error: symbolName is required");
 
-                if (!File.Exists(solutionPath))
-                    return CreateToolError($"Error: Solution file not found: {solutionPath}");
-
-                var result = await GetGraphImpactAsync(solutionPath, symbolName, maxDepth, includeTests);
+                var result = await GetGraphImpactAsync(solutionPath!, symbolName, maxDepth, includeTests);
                 return CreateToolResponse(result, !result.Success);
             });
     }
@@ -139,7 +135,9 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
+
                 var includePrivate = args?["includePrivate"]?.GetValue<bool>() ?? false;
                 var includeTests = args?["includeTests"]?.GetValue<bool>() ?? false;
                 var maxResults = args?["maxResults"]?.GetValue<int>() ?? 100;
@@ -155,14 +153,8 @@ public static partial class RoslynTools
                     .Where(s => !string.IsNullOrEmpty(s))
                     .ToArray() ?? DefaultExcludeFilePatterns;
 
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                    return CreateToolError("Error: solutionPath is required");
-
-                if (!File.Exists(solutionPath))
-                    return CreateToolError($"Error: Solution file not found: {solutionPath}");
-
                 var result = await FindDeadCodeAsync(
-                    solutionPath, includePrivate, includeTests, maxResults,
+                    solutionPath!, includePrivate, includeTests, maxResults,
                     excludeTypePatterns, excludeFilePatterns);
                 return CreateToolResponse(result, !result.Success);
             });
@@ -501,8 +493,8 @@ public static partial class RoslynTools
         }
     }
 
-    private static readonly string[] definitionArray100 = new[] { "solutionPath" };
-    private static readonly string[] definitionArray0 = new[] { "solutionPath", "symbolName" };
+    private static readonly string[] definitionArray100 = Array.Empty<string>();
+    private static readonly string[] definitionArray0 = new[] { "symbolName" };
 
     private static bool IsTestFile(string filePath)
     {

--- a/src/RoslynTools.GraphImpact.cs
+++ b/src/RoslynTools.GraphImpact.cs
@@ -194,6 +194,9 @@ public static partial class RoslynTools
             };
         }
 
+        // Get solution directory for relative paths (Issue #115)
+        var solutionDir = Path.GetDirectoryName(solutionPath) ?? "";
+
         // Use FindSymbolAsync for partial name matching (Issue #33)
         var searchResult = await db.FindSymbolAsync(solution.Id, symbolName);
 
@@ -240,7 +243,7 @@ public static partial class RoslynTools
             .GroupBy(c => c.FilePath)
             .Select(g => new AffectedFile
             {
-                FilePath = g.Key,
+                FilePath = GetRelativePath(g.Key, solutionDir),
                 FileName = Path.GetFileName(g.Key),
                 AffectedSymbols = g.Select(s => new AffectedSymbol
                 {
@@ -261,7 +264,7 @@ public static partial class RoslynTools
                 Name = symbol.Name,
                 QualifiedName = symbol.QualifiedName,
                 Kind = symbol.Kind.ToString(),
-                FilePath = symbol.FilePath,
+                FilePath = GetRelativePath(symbol.FilePath, solutionDir),
                 Line = symbol.Line
             },
             TotalAffectedSymbols = filteredCallers.Count,
@@ -297,6 +300,9 @@ public static partial class RoslynTools
                 Error = "Solution not found in graph database."
             };
         }
+
+        // Get solution directory for relative paths (Issue #115)
+        var solutionDir = Path.GetDirectoryName(solutionPath) ?? "";
 
         // Get all symbols that are methods or properties
         // Issue #36: Filter out external symbols (BCL, framework types)
@@ -376,7 +382,7 @@ public static partial class RoslynTools
                     Name = symbol.Name,
                     QualifiedName = symbol.QualifiedName,
                     Kind = symbol.Kind.ToString(),
-                    FilePath = symbol.FilePath,
+                    FilePath = GetRelativePath(symbol.FilePath, solutionDir),
                     FileName = Path.GetFileName(symbol.FilePath),
                     Line = symbol.Line
                 });

--- a/src/RoslynTools.Implementations.cs
+++ b/src/RoslynTools.Implementations.cs
@@ -4,7 +4,7 @@ namespace RoslynMcpServer;
 
 public static partial class RoslynTools
 {
-    private static readonly string[] definitionArray26 = new[] { "solutionPath", "typeName" };
+    private static readonly string[] definitionArray26 = new[] { "typeName" };
 
     /// <summary>
     /// Finds all implementations of an interface or derived classes.
@@ -54,20 +54,10 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
-                var typeName = args?["typeName"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
 
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                {
-                    return new
-                    {
-                        content = new[]
-                        {
-                            new { type = "text", text = "Error: solutionPath is required" }
-                        },
-                        isError = true
-                    };
-                }
+                var typeName = args?["typeName"]?.GetValue<string>();
 
                 if (string.IsNullOrWhiteSpace(typeName))
                 {
@@ -85,7 +75,7 @@ public static partial class RoslynTools
                 var maxResults = args?["maxResults"]?.GetValue<int>() ?? 100;
 
                 var result = await SolutionAnalyzerService.FindImplementationsAsync(
-                    solutionPath,
+                    solutionPath!,
                     typeName,
                     includeBaseType,
                     maxResults);

--- a/src/RoslynTools.Knowledge.cs
+++ b/src/RoslynTools.Knowledge.cs
@@ -9,7 +9,7 @@ namespace RoslynMcpServer;
 public static partial class RoslynTools
 {
     private static readonly Dictionary<string, (KnowledgeDatabase Db, SmartComponentsEmbeddingProvider Embedder)> _knowledgeDatabases = new();
-    private static readonly string[] definitionArrayKnowledge = ["solutionPath", "category", "title", "content"];
+    private static readonly string[] definitionArrayKnowledge = ["category", "title", "content"];
 
     /// <summary>
     /// Gets or creates a KnowledgeDatabase for the specified solution.
@@ -102,13 +102,10 @@ public static partial class RoslynTools
     /// </summary>
     private static async Task<object> HandleKnowledgeAddAsync(JsonObject? args)
     {
-        if (!TryGetRequiredString(args, "solutionPath", out var solutionPath, out var error))
-            return error!;
+        var (solutionPath, solutionError) = GetSolutionPathOrError();
+        if (solutionError != null) return solutionError;
 
-        if (!TryValidateSolutionPath(solutionPath, out error))
-            return error!;
-
-        if (!TryGetRequiredString(args, "category", out var category, out error))
+        if (!TryGetRequiredString(args, "category", out var category, out var error))
             return error!;
 
         if (!TryGetRequiredString(args, "title", out var title, out error))
@@ -123,7 +120,7 @@ public static partial class RoslynTools
 
         try
         {
-            var db = await GetKnowledgeDatabaseAsync(solutionPath);
+            var db = await GetKnowledgeDatabaseAsync(solutionPath!);
 
             var input = new AddKnowledgeInput
             {
@@ -204,7 +201,7 @@ public static partial class RoslynTools
                             maximum = 50
                         }
                     },
-                    required = new[] { "solutionPath", "query" }
+                    required = new[] { "query" }
                 },
                 Annotations = new ToolAnnotations
                 {
@@ -214,23 +211,19 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
+
                 var query = args?["query"]?.GetValue<string>();
                 var symbols = args?["symbols"]?.AsArray()?.Select(x => x?.GetValue<string>() ?? "").Where(s => !string.IsNullOrEmpty(s)).ToArray();
                 var limit = args?["limit"]?.GetValue<int>() ?? 10;
-
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                    return CreateErrorResponse("Error: solutionPath is required");
-
-                if (!File.Exists(solutionPath))
-                    return CreateErrorResponse($"Error: Solution file not found: {solutionPath}");
 
                 if (string.IsNullOrWhiteSpace(query))
                     return CreateErrorResponse("Error: query is required");
 
                 try
                 {
-                    var db = await GetKnowledgeDatabaseAsync(solutionPath);
+                    var db = await GetKnowledgeDatabaseAsync(solutionPath!);
                     var results = await db.SearchAsync(query, symbols, limit);
 
                     return CreateJsonResponse(new
@@ -303,7 +296,7 @@ public static partial class RoslynTools
                             minimum = 0
                         }
                     },
-                    required = new[] { "solutionPath" }
+                    required = Array.Empty<string>()
                 },
                 Annotations = new ToolAnnotations
                 {
@@ -313,21 +306,17 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
+
                 var category = args?["category"]?.GetValue<string>();
                 var tag = args?["tag"]?.GetValue<string>();
                 var limit = args?["limit"]?.GetValue<int>() ?? 100;
                 var offset = args?["offset"]?.GetValue<int>() ?? 0;
 
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                    return CreateErrorResponse("Error: solutionPath is required");
-
-                if (!File.Exists(solutionPath))
-                    return CreateErrorResponse($"Error: Solution file not found: {solutionPath}");
-
                 try
                 {
-                    var db = await GetKnowledgeDatabaseAsync(solutionPath);
+                    var db = await GetKnowledgeDatabaseAsync(solutionPath!);
                     var entries = await db.ListEntriesAsync(category, tag, limit, offset);
                     var totalCount = await db.GetEntryCountAsync();
 
@@ -383,7 +372,7 @@ public static partial class RoslynTools
                             description = "ID of the knowledge entry to delete"
                         }
                     },
-                    required = new[] { "solutionPath", "id" }
+                    required = new[] { "id" }
                 },
                 Annotations = new ToolAnnotations
                 {
@@ -393,21 +382,17 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
+
                 var id = args?["id"]?.GetValue<long>() ?? 0;
-
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                    return CreateErrorResponse("Error: solutionPath is required");
-
-                if (!File.Exists(solutionPath))
-                    return CreateErrorResponse($"Error: Solution file not found: {solutionPath}");
 
                 if (id <= 0)
                     return CreateErrorResponse("Error: valid id is required");
 
                 try
                 {
-                    var db = await GetKnowledgeDatabaseAsync(solutionPath);
+                    var db = await GetKnowledgeDatabaseAsync(solutionPath!);
                     var deleted = await db.DeleteEntryAsync(id);
 
                     if (deleted)
@@ -456,7 +441,7 @@ public static partial class RoslynTools
                             description = "ID of the knowledge entry to retrieve"
                         }
                     },
-                    required = new[] { "solutionPath", "id" }
+                    required = new[] { "id" }
                 },
                 Annotations = new ToolAnnotations
                 {
@@ -466,21 +451,17 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
+
                 var id = args?["id"]?.GetValue<long>() ?? 0;
-
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                    return CreateErrorResponse("Error: solutionPath is required");
-
-                if (!File.Exists(solutionPath))
-                    return CreateErrorResponse($"Error: Solution file not found: {solutionPath}");
 
                 if (id <= 0)
                     return CreateErrorResponse("Error: valid id is required");
 
                 try
                 {
-                    var db = await GetKnowledgeDatabaseAsync(solutionPath);
+                    var db = await GetKnowledgeDatabaseAsync(solutionPath!);
                     var entry = await db.GetEntryByIdAsync(id);
 
                     if (entry == null)
@@ -538,7 +519,7 @@ public static partial class RoslynTools
                             description = "Qualified symbol name (e.g., 'MyNamespace.MyClass.MyMethod')"
                         }
                     },
-                    required = new[] { "solutionPath", "symbolName" }
+                    required = new[] { "symbolName" }
                 },
                 Annotations = new ToolAnnotations
                 {
@@ -548,21 +529,17 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
+
                 var symbolName = args?["symbolName"]?.GetValue<string>();
-
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                    return CreateErrorResponse("Error: solutionPath is required");
-
-                if (!File.Exists(solutionPath))
-                    return CreateErrorResponse($"Error: Solution file not found: {solutionPath}");
 
                 if (string.IsNullOrWhiteSpace(symbolName))
                     return CreateErrorResponse("Error: symbolName is required");
 
                 try
                 {
-                    var db = await GetKnowledgeDatabaseAsync(solutionPath);
+                    var db = await GetKnowledgeDatabaseAsync(solutionPath!);
                     var entries = await db.GetEntriesForSymbolAsync(symbolName);
 
                     return CreateJsonResponse(new

--- a/src/RoslynTools.MethodBody.cs
+++ b/src/RoslynTools.MethodBody.cs
@@ -4,7 +4,7 @@ namespace RoslynMcpServer;
 
 public static partial class RoslynTools
 {
-    private static readonly string[] definitionArray27 = new[] { "solutionPath", "typeName", "methodName" };
+    private static readonly string[] definitionArray27 = new[] { "typeName", "methodName" };
 
     /// <summary>
     /// Gets the full source code of a method including its body.
@@ -52,22 +52,12 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
+
                 var typeName = args?["typeName"]?.GetValue<string>();
                 var methodName = args?["methodName"]?.GetValue<string>();
                 var parameterTypes = args?["parameterTypes"]?.GetValue<string>();
-
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                {
-                    return new
-                    {
-                        content = new[]
-                        {
-                            new { type = "text", text = "Error: solutionPath is required" }
-                        },
-                        isError = true
-                    };
-                }
 
                 if (string.IsNullOrWhiteSpace(typeName))
                 {
@@ -94,14 +84,14 @@ public static partial class RoslynTools
                 }
 
                 var result = await SolutionAnalyzerService.GetMethodBodyAsync(
-                    solutionPath,
+                    solutionPath!,
                     typeName,
                     methodName,
                     parameterTypes);
 
                 // Track for visualization sync
                 if (result.Success)
-                    LastSymbolTracker.Track(solutionPath, $"{typeName}.{methodName}", "method");
+                    LastSymbolTracker.Track(solutionPath!, $"{typeName}.{methodName}", "method");
 
                 // Fetch related knowledge entries
                 List<object>? knowledge = null;
@@ -109,7 +99,7 @@ public static partial class RoslynTools
                 {
                     try
                     {
-                        var db = await GetKnowledgeDatabaseAsync(solutionPath);
+                        var db = await GetKnowledgeDatabaseAsync(solutionPath!);
                         // Use fully qualified type name from result
                         var fullyQualifiedSymbol = $"{result.TypeName}.{methodName}";
                         var entries = await db.GetEntriesForSymbolAsync(fullyQualifiedSymbol);

--- a/src/RoslynTools.References.cs
+++ b/src/RoslynTools.References.cs
@@ -4,7 +4,7 @@ namespace RoslynMcpServer;
 
 public static partial class RoslynTools
 {
-    private static readonly string[] definitionArray28 = new[] { "solutionPath", "filePath", "line", "column" };
+    private static readonly string[] definitionArray28 = new[] { "filePath", "line", "column" };
 
     /// <summary>
     /// Finds all references to a symbol at a given position.
@@ -71,22 +71,12 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
+
                 var filePath = args?["filePath"]?.GetValue<string>();
                 var line = args?["line"]?.GetValue<int>() ?? 0;
                 var column = args?["column"]?.GetValue<int>() ?? 0;
-
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                {
-                    return new
-                    {
-                        content = new[]
-                        {
-                            new { type = "text", text = "Error: solutionPath is required" }
-                        },
-                        isError = true
-                    };
-                }
 
                 if (string.IsNullOrWhiteSpace(filePath))
                 {
@@ -130,7 +120,7 @@ public static partial class RoslynTools
                 var fileFilter = args?["fileFilter"]?.GetValue<string>();
 
                 var result = await SolutionAnalyzerService.FindReferencesAsync(
-                    solutionPath,
+                    solutionPath!,
                     filePath,
                     line,
                     column,

--- a/src/RoslynTools.RemoveUsings.cs
+++ b/src/RoslynTools.RemoveUsings.cs
@@ -40,7 +40,7 @@ public static partial class RoslynTools
                             description = "If true, shows what would be removed without making changes. Default: false"
                         }
                     },
-                    required = new[] { "solutionPath" }
+                    required = Array.Empty<string>()
                 },
                 Annotations = new ToolAnnotations
                 {
@@ -50,25 +50,15 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
+
                 var projectFilter = args?["projectFilter"]?.GetValue<string>();
                 var fileFilter = args?["fileFilter"]?.GetValue<string>();
                 var preview = args?["preview"]?.GetValue<bool>() ?? false;
 
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                {
-                    return new
-                    {
-                        content = new[]
-                        {
-                            new { type = "text", text = "Error: solutionPath is required" }
-                        },
-                        isError = true
-                    };
-                }
-
                 var result = await SolutionAnalyzerService.RemoveUnnecessaryUsingsAsync(
-                    solutionPath,
+                    solutionPath!,
                     projectFilter,
                     fileFilter,
                     preview);

--- a/src/RoslynTools.Rename.cs
+++ b/src/RoslynTools.Rename.cs
@@ -4,7 +4,7 @@ namespace RoslynMcpServer;
 
 public static partial class RoslynTools
 {
-    private static readonly string[] definitionArray29 = new[] { "solutionPath", "filePath", "line", "column", "newName" };
+    private static readonly string[] definitionArray29 = new[] { "filePath", "line", "column", "newName" };
 
     private static void RegisterRenameSymbolTool(McpServer server)
     {
@@ -57,23 +57,13 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
+
                 var filePath = args?["filePath"]?.GetValue<string>();
                 var line = args?["line"]?.GetValue<int>() ?? 0;
                 var column = args?["column"]?.GetValue<int>() ?? 0;
                 var newName = args?["newName"]?.GetValue<string>();
-
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                {
-                    return new
-                    {
-                        content = new[]
-                        {
-                            new { type = "text", text = "Error: solutionPath is required" }
-                        },
-                        isError = true
-                    };
-                }
 
                 if (string.IsNullOrWhiteSpace(filePath))
                 {
@@ -124,7 +114,7 @@ public static partial class RoslynTools
                 }
 
                 var result = await SolutionAnalyzerService.RenameSymbolAsync(
-                    solutionPath, filePath, line, column, newName);
+                    solutionPath!, filePath, line, column, newName);
 
                 return new
                 {

--- a/src/RoslynTools.TypeMembers.cs
+++ b/src/RoslynTools.TypeMembers.cs
@@ -5,7 +5,7 @@ namespace RoslynMcpServer;
 public static partial class RoslynTools
 {
     private static readonly string[] definitionArray32 = new[] { "all", "methods", "properties", "fields", "events", "constructors" };
-    private static readonly string[] definitionArray33 = new[] { "solutionPath", "typeName" };
+    private static readonly string[] definitionArray33 = new[] { "typeName" };
 
     /// <summary>
     /// Gets all members of a type (methods, properties, fields, events, constructors).
@@ -59,20 +59,10 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
-                var typeName = args?["typeName"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
 
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                {
-                    return new
-                    {
-                        content = new[]
-                        {
-                            new { type = "text", text = "Error: solutionPath is required" }
-                        },
-                        isError = true
-                    };
-                }
+                var typeName = args?["typeName"]?.GetValue<string>();
 
                 if (string.IsNullOrWhiteSpace(typeName))
                 {
@@ -102,7 +92,7 @@ public static partial class RoslynTools
                 };
 
                 var result = await SolutionAnalyzerService.GetTypeMembersAsync(
-                    solutionPath,
+                    solutionPath!,
                     typeName,
                     memberKind,
                     includeInherited,
@@ -110,7 +100,7 @@ public static partial class RoslynTools
 
                 // Track for visualization sync
                 if (result.Success)
-                    LastSymbolTracker.Track(solutionPath, typeName, "type");
+                    LastSymbolTracker.Track(solutionPath!, typeName, "type");
 
                 return new
                 {

--- a/src/RoslynTools.UpdateMethod.cs
+++ b/src/RoslynTools.UpdateMethod.cs
@@ -55,23 +55,13 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
+
                 var typeName = args?["typeName"]?.GetValue<string>();
                 var methodName = args?["methodName"]?.GetValue<string>();
                 var newSourceCode = args?["newSourceCode"]?.GetValue<string>();
                 var parameterTypes = args?["parameterTypes"]?.GetValue<string>();
-
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                {
-                    return new
-                    {
-                        content = new[]
-                        {
-                            new { type = "text", text = "Error: solutionPath is required" }
-                        },
-                        isError = true
-                    };
-                }
 
                 if (string.IsNullOrWhiteSpace(typeName))
                 {
@@ -110,7 +100,7 @@ public static partial class RoslynTools
                 }
 
                 var result = await SolutionAnalyzerService.UpdateMethodAsync(
-                    solutionPath,
+                    solutionPath!,
                     typeName,
                     methodName,
                     newSourceCode,
@@ -127,5 +117,5 @@ public static partial class RoslynTools
             });
     }
 
-    private static readonly string[] definitionArray34 = new[] { "solutionPath", "typeName", "methodName", "newSourceCode" };
+    private static readonly string[] definitionArray34 = new[] { "typeName", "methodName", "newSourceCode" };
 }

--- a/src/RoslynTools.cs
+++ b/src/RoslynTools.cs
@@ -16,11 +16,35 @@ public static partial class RoslynTools
     private static SolutionAnalyzerService? _analyzerService;
 
     /// <summary>
+    /// Auto-detected solution path. Set at startup, used by all tools.
+    /// Issue: #115
+    /// </summary>
+    private static string? _solutionPath;
+
+    /// <summary>
+    /// Solution directory for relative path calculations.
+    /// </summary>
+    private static string _solutionDir = "";
+
+    /// <summary>
     /// Registers all tools with the MCP server.
     /// </summary>
     public static void RegisterAll(McpServer server, SolutionAnalyzerService? analyzerService = null)
     {
         _analyzerService = analyzerService ?? new SolutionAnalyzerService();
+
+        // Auto-detect solution path at startup (Issue #115)
+        _solutionPath = DetectSolutionPath();
+        _solutionDir = _solutionPath != null ? Path.GetDirectoryName(_solutionPath) ?? "" : "";
+
+        if (_solutionPath != null)
+        {
+            Console.Error.WriteLine($"Auto-detected solution: {Path.GetFileName(_solutionPath)}");
+        }
+        else
+        {
+            Console.Error.WriteLine("Warning: No solution file detected. Run from solution directory or use --init.");
+        }
 
         RegisterEchoTool(server);
         RegisterGetServerInfoTool(server);


### PR DESCRIPTION
## Summary
- Auto-detect solution path at MCP server startup (looks for .sln/.slnx in exe directory)
- Removed `solutionPath` parameter requirement from ALL tools
- Tools now use `GetSolutionPathOrError()` helper for consistent error handling
- Reduces token usage per tool call (no need to pass solutionPath every time)

## Changes
- Added `_solutionPath` static field and `DetectSolutionPath()` method in RoslynTools.cs
- Added `GetSolutionPathOrError()` helper method for all tool handlers
- Updated 20+ tool handlers to use auto-detected solution path
- Removed "solutionPath" from required arrays in all tool definitions

## Tools Updated
- roslyn_find_symbol, roslyn_get_type_members, roslyn_get_method_body
- roslyn_get_references, roslyn_get_callers, roslyn_get_implementations
- roslyn_update_method, roslyn_delete_member, roslyn_add_type, roslyn_add_member
- roslyn_get_diagnostics, roslyn_apply_code_fix, roslyn_batch_apply_code_fixes
- roslyn_remove_unnecessary_usings, roslyn_extract_method, roslyn_rename_symbol
- roslyn_graph_status, roslyn_graph_analyze, roslyn_query_graph, roslyn_graph_impact, roslyn_find_dead_code
- roslyn_knowledge_add, roslyn_knowledge_search, roslyn_knowledge_list, roslyn_knowledge_delete, roslyn_knowledge_get, roslyn_knowledge_for_symbol

## Test plan
- [x] Build succeeds with 0 warnings, 0 errors
- [x] All 109 tests pass
- [x] Manual test: roslyn_find_symbol works without solutionPath parameter
- [x] Auto-detection correctly identifies solution file

Fixes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)