### PR TITLE
Optimize Roslyn tool DTOs for compact output

### DIFF
--- a/src/RoslynTools.Callers.cs
+++ b/src/RoslynTools.Callers.cs
@@ -103,32 +103,68 @@ public static partial class RoslynTools
         var projectFilter = args?["projectFilter"]?.GetValue<string>();
         var fileFilter = args?["fileFilter"]?.GetValue<string>();
 
+        GetCallersResult? result = null;
+
         // Try graph cache first
         var graphResult = await TryGetCallersFromGraphAsync(
             solutionPath!, filePath, line, column, maxResults, offset, projectFilter, fileFilter);
 
         if (graphResult != null)
         {
-            return CreateSuccessResponse(graphResult, !graphResult.Success);
+            result = graphResult;
+        }
+        else
+        {
+            // Fall back to live analysis
+            var liveResult = await SolutionAnalyzerService.GetCallersAsync(
+                solutionPath!, filePath, line, column, maxResults, offset, projectFilter, fileFilter);
+
+            result = new GetCallersResult
+            {
+                Success = liveResult.Success,
+                Error = liveResult.Error,
+                Symbol = liveResult.Symbol,
+                TotalCallers = liveResult.TotalCallers,
+                ReturnedCount = liveResult.ReturnedCount,
+                Source = "live",
+                Callers = liveResult.Callers
+            };
         }
 
-        // Fall back to live analysis
-        var result = await SolutionAnalyzerService.GetCallersAsync(
-            solutionPath!, filePath, line, column, maxResults, offset, projectFilter, fileFilter);
-
-        // Add source indicator for live analysis
-        var liveResult = new GetCallersResult
+        if (!result.Success)
         {
-            Success = result.Success,
-            Error = result.Error,
-            Symbol = result.Symbol,
-            TotalCallers = result.TotalCallers,
-            ReturnedCount = result.ReturnedCount,
-            Source = "live",
-            Callers = result.Callers
+            return new
+            {
+                content = new[]
+                {
+                    new { type = "text", text = result.Error ?? "Failed to find callers" }
+                },
+                isError = true
+            };
+        }
+
+        // Build compact response: "Type.Method file:line"
+        var compactCallers = result.Callers?.Select(c =>
+        {
+            var caller = string.IsNullOrEmpty(c.Type) ? c.Method : $"{c.Type}.{c.Method}";
+            return $"{caller} {c.File}:{c.Line}";
+        }).ToList() ?? new List<string>();
+
+        var compactResult = new
+        {
+            symbol = result.Symbol ?? "unknown",
+            count = result.TotalCallers,
+            callers = compactCallers
         };
 
-        return CreateSuccessResponse(liveResult, !liveResult.Success);
+        return new
+        {
+            content = new[]
+            {
+                new { type = "text", text = JsonSerializer.Serialize(compactResult, JsonOptions) }
+            },
+            isError = false
+        };
     }
 
     /// <summary>

--- a/src/RoslynTools.Diagnostics.cs
+++ b/src/RoslynTools.Diagnostics.cs
@@ -84,13 +84,63 @@ public static partial class RoslynTools
                     maxResults,
                     offset);
 
+                if (!result.Success)
+                {
+                    return new
+                    {
+                        content = new[]
+                        {
+                            new { type = "text", text = result.Error ?? "Failed to get diagnostics" }
+                        },
+                        isError = true
+                    };
+                }
+
+                object compactResult;
+
+                if (result.Summary != null)
+                {
+                    // Summary mode: "CS0618 (warning) [fix]: Description (count)"
+                    var compactSummary = result.Summary.Select(s =>
+                    {
+                        var fixFlag = s.FixAvailable ? " [fix]" : "";
+                        var suppressed = s.SuppressedCount > 0 ? $" ({s.SuppressedCount} suppressed)" : "";
+                        return $"{s.Id} ({s.Severity}){fixFlag}: {s.Title} ({s.Count}){suppressed}";
+                    }).ToList();
+
+                    compactResult = new
+                    {
+                        errors = result.TotalErrors,
+                        warnings = result.TotalWarnings,
+                        summary = compactSummary
+                    };
+                }
+                else
+                {
+                    // Detail mode: "file:line Type.Method - message"
+                    var compactEntries = result.Entries?.Select(e =>
+                    {
+                        var relativePath = GetRelativePath(e.FilePath, solutionPath!);
+                        var location = !string.IsNullOrEmpty(e.ContainingType)
+                            ? $"{e.ContainingType}.{e.ContainingMethod}"
+                            : "";
+                        return $"{relativePath}:{e.Line} {location} - {e.Message}";
+                    }).ToList() ?? new List<string>();
+
+                    compactResult = new
+                    {
+                        total = result.TotalMatchingEntries,
+                        entries = compactEntries
+                    };
+                }
+
                 return new
                 {
                     content = new[]
                     {
-                        new { type = "text", text = JsonSerializer.Serialize(result, JsonOptions) }
+                        new { type = "text", text = JsonSerializer.Serialize(compactResult, JsonOptions) }
                     },
-                    isError = !result.Success
+                    isError = false
                 };
             });
     }

--- a/src/RoslynTools.FindSymbol.cs
+++ b/src/RoslynTools.FindSymbol.cs
@@ -99,35 +99,30 @@ public static partial class RoslynTools
     private static async Task<object> BuildFindSymbolResponseAsync(string solutionPath, FindSymbolResult result)
     {
         if (!result.Success || result.Symbols == null || result.Symbols.Count == 0)
-            return result;
+        {
+            return new
+            {
+                count = 0,
+                symbols = Array.Empty<string>()
+            };
+        }
 
         var knowledgeSymbols = await GetKnowledgeSymbolLinksAsync(solutionPath);
-        if (knowledgeSymbols.Count == 0)
-            return result;
+        var solutionDir = Path.GetDirectoryName(solutionPath) ?? "";
 
-        var symbolsWithFlags = result.Symbols.Select(s => new
+        // Format: "Namespace.Type.Member (Kind) path:line [K]"
+        var compactSymbols = result.Symbols.Select(s =>
         {
-            s.Name,
-            s.FullyQualifiedName,
-            s.Kind,
-            s.FilePath,
-            s.Line,
-            s.Column,
-            s.ContainingType,
-            s.Accessibility,
-            s.IsStatic,
-            s.Signature,
-            HasKnowledge = HasKnowledgeEntry(s.FullyQualifiedName, knowledgeSymbols)
+            var relativePath = GetRelativePath(s.FilePath ?? "", solutionPath);
+            var hasKnowledge = HasKnowledgeEntry(s.FullyQualifiedName, knowledgeSymbols);
+            var knowledgeFlag = hasKnowledge ? " [K]" : "";
+            return $"{s.FullyQualifiedName} ({s.Kind}) {relativePath}:{s.Line}{knowledgeFlag}";
         }).ToList();
 
         return new
         {
-            result.Success,
-            result.Error,
-            result.SolutionPath,
-            result.Pattern,
-            result.TotalFound,
-            Symbols = symbolsWithFlags
+            count = result.TotalFound,
+            symbols = compactSymbols
         };
     }
 }

--- a/src/RoslynTools.Graph.cs
+++ b/src/RoslynTools.Graph.cs
@@ -43,7 +43,26 @@ public static partial class RoslynTools
                 if (solutionError != null) return solutionError;
 
                 var result = await GetGraphStatusAsync(solutionPath!);
-                return CreateJsonResponse(result);
+
+                if (!result.Success || !result.GraphExists)
+                {
+                    return CreateJsonResponse(new
+                    {
+                        exists = false,
+                        message = result.Message ?? "No graph database found. Run roslyn_graph_analyze first."
+                    });
+                }
+
+                // Compact format
+                var compactResult = new
+                {
+                    exists = true,
+                    lastAnalyzed = result.LastAnalyzed?.ToString("yyyy-MM-dd HH:mm:ss"),
+                    symbols = result.SymbolStats != null ? $"{result.SymbolStats.Analyzed}/{result.SymbolStats.Total} ({result.SymbolStats.Dirty} dirty)" : null,
+                    edges = result.EdgeStats?.Total
+                };
+
+                return CreateJsonResponse(compactResult);
             });
     }
 
@@ -95,7 +114,21 @@ public static partial class RoslynTools
                 var projectFilter = args?["projectFilter"]?.GetValue<string>();
 
                 var result = await AnalyzeGraphAsync(solutionPath!, incremental, projectFilter);
-                return CreateJsonResponse(result, !result.Success);
+
+                if (!result.Success)
+                {
+                    return CreateJsonResponse(new { error = result.Error }, true);
+                }
+
+                // Compact format
+                var compactResult = new
+                {
+                    documents = result.DocumentsAnalyzed,
+                    symbols = result.SymbolsFound,
+                    edges = result.EdgesFound
+                };
+
+                return CreateJsonResponse(compactResult);
             });
     }
 
@@ -161,7 +194,27 @@ public static partial class RoslynTools
                 }
 
                 var result = await QueryGraphAsync(solutionPath!, symbolName, direction, maxDepth);
-                return CreateJsonResponse(result, !result.Success);
+
+                if (!result.Success)
+                {
+                    return CreateJsonResponse(new { error = result.Error }, true);
+                }
+
+                // Compact format: "QualifiedName file:line"
+                var formatEntry = (GraphSymbolEntry e) => $"{e.QualifiedName} {e.FilePath}:{e.Line}";
+
+                var compactResult = new Dictionary<string, object?>
+                {
+                    ["symbol"] = result.Symbol?.QualifiedName ?? symbolName
+                };
+
+                if (result.Callers != null && result.Callers.Count > 0)
+                    compactResult["callers"] = result.Callers.Select(formatEntry).ToList();
+
+                if (result.Callees != null && result.Callees.Count > 0)
+                    compactResult["callees"] = result.Callees.Select(formatEntry).ToList();
+
+                return CreateJsonResponse(compactResult);
             });
     }
 

--- a/src/RoslynTools.GraphImpact.cs
+++ b/src/RoslynTools.GraphImpact.cs
@@ -67,7 +67,28 @@ public static partial class RoslynTools
                     return CreateToolError("Error: symbolName is required");
 
                 var result = await GetGraphImpactAsync(solutionPath!, symbolName, maxDepth, includeTests);
-                return CreateToolResponse(result, !result.Success);
+
+                if (!result.Success)
+                {
+                    return CreateToolResponse(new { error = result.Error }, true);
+                }
+
+                // Compact format: group by file, list affected symbols
+                var compactFiles = result.AffectedFiles?.Select(f => new
+                {
+                    file = f.FileName,
+                    symbols = f.AffectedSymbols.Select(s => $"{s.Name}:{s.Line}").ToList()
+                }).ToList();
+
+                var compactResult = new
+                {
+                    symbol = result.Symbol?.QualifiedName ?? symbolName,
+                    affectedFiles = result.TotalAffectedFiles,
+                    affectedSymbols = result.TotalAffectedSymbols,
+                    files = compactFiles
+                };
+
+                return CreateToolResponse(compactResult, false);
             });
     }
 

--- a/src/RoslynTools.Implementations.cs
+++ b/src/RoslynTools.Implementations.cs
@@ -80,13 +80,40 @@ public static partial class RoslynTools
                     includeBaseType,
                     maxResults);
 
+                if (!result.Success)
+                {
+                    return new
+                    {
+                        content = new[]
+                        {
+                            new { type = "text", text = result.Error ?? "Failed to find implementations" }
+                        },
+                        isError = true
+                    };
+                }
+
+                // Build compact response: "Namespace.Type (Kind) path:line"
+                var compactImpls = result.Implementations?.Select(i =>
+                {
+                    var relativePath = GetRelativePath(i.FilePath ?? "", solutionPath!);
+                    var abstractFlag = i.IsAbstract ? " [abstract]" : "";
+                    return $"{i.FullyQualifiedName} ({i.Kind}){abstractFlag} {relativePath}:{i.Line}";
+                }).ToList() ?? new List<string>();
+
+                var compactResult = new
+                {
+                    baseType = result.BaseType?.FullyQualifiedName ?? typeName,
+                    count = result.TotalFound,
+                    implementations = compactImpls
+                };
+
                 return new
                 {
                     content = new[]
                     {
-                        new { type = "text", text = JsonSerializer.Serialize(result, JsonOptions) }
+                        new { type = "text", text = JsonSerializer.Serialize(compactResult, JsonOptions) }
                     },
-                    isError = !result.Success
+                    isError = false
                 };
             });
     }

--- a/src/RoslynTools.MethodBody.cs
+++ b/src/RoslynTools.MethodBody.cs
@@ -89,22 +89,39 @@ public static partial class RoslynTools
                     methodName,
                     parameterTypes);
 
+                if (!result.Success)
+                {
+                    var errorResponse = new Dictionary<string, object?>
+                    {
+                        ["error"] = result.Error
+                    };
+                    if (result.AvailableOverloads != null && result.AvailableOverloads.Count > 0)
+                    {
+                        errorResponse["availableOverloads"] = result.AvailableOverloads;
+                    }
+                    return new
+                    {
+                        content = new[]
+                        {
+                            new { type = "text", text = JsonSerializer.Serialize(errorResponse, JsonOptions) }
+                        },
+                        isError = true
+                    };
+                }
+
                 // Track for visualization sync
-                if (result.Success)
-                    LastSymbolTracker.Track(solutionPath!, $"{typeName}.{methodName}", "method");
+                LastSymbolTracker.Track(solutionPath!, $"{typeName}.{methodName}", "method");
 
                 // Fetch related knowledge entries
                 List<object>? knowledge = null;
-                if (result.Success && result.TypeName != null)
+                if (result.TypeName != null)
                 {
                     try
                     {
                         var db = await GetKnowledgeDatabaseAsync(solutionPath!);
-                        // Use fully qualified type name from result
                         var fullyQualifiedSymbol = $"{result.TypeName}.{methodName}";
                         var entries = await db.GetEntriesForSymbolAsync(fullyQualifiedSymbol);
 
-                        // Also search for type-level knowledge
                         var typeEntries = await db.GetEntriesForSymbolAsync(result.TypeName);
                         entries.AddRange(typeEntries.Where(e => !entries.Any(x => x.Id == e.Id)));
 
@@ -114,9 +131,7 @@ public static partial class RoslynTools
                             {
                                 e.Id,
                                 e.Category,
-                                e.Title,
-                                e.Content,
-                                e.Confidence
+                                e.Title
                             }).ToList();
                         }
                     }
@@ -126,30 +141,25 @@ public static partial class RoslynTools
                     }
                 }
 
-                // Build response with optional knowledge
-                var response = new
+                // Build compact response
+                var relativePath = GetRelativePath(result.FilePath ?? "", solutionPath!);
+                var compactResult = new Dictionary<string, object?>
                 {
-                    result.Success,
-                    result.Error,
-                    result.SolutionPath,
-                    result.TypeName,
-                    result.MethodName,
-                    result.FilePath,
-                    result.StartLine,
-                    result.EndLine,
-                    result.Signature,
-                    result.SourceCode,
-                    result.AvailableOverloads,
-                    Knowledge = knowledge
+                    ["file"] = $"{relativePath}:{result.StartLine}-{result.EndLine}",
+                    ["signature"] = result.Signature,
+                    ["code"] = result.SourceCode
                 };
+
+                if (knowledge != null)
+                    compactResult["knowledge"] = knowledge;
 
                 return new
                 {
                     content = new[]
                     {
-                        new { type = "text", text = JsonSerializer.Serialize(response, JsonOptions) }
+                        new { type = "text", text = JsonSerializer.Serialize(compactResult, JsonOptions) }
                     },
-                    isError = !result.Success
+                    isError = false
                 };
             });
     }

--- a/src/RoslynTools.References.cs
+++ b/src/RoslynTools.References.cs
@@ -128,13 +128,39 @@ public static partial class RoslynTools
                     projectFilter,
                     fileFilter);
 
+                if (!result.Success)
+                {
+                    return new
+                    {
+                        content = new[]
+                        {
+                            new { type = "text", text = result.Error ?? "Failed to find references" }
+                        },
+                        isError = true
+                    };
+                }
+
+                // Build compact response
+                var compactRefs = result.References?.Select(r =>
+                {
+                    var relativePath = GetRelativePath(r.FilePath ?? "", solutionPath!);
+                    return $"{relativePath}:{r.Line} - {r.Preview}";
+                }).ToList() ?? new List<string>();
+
+                var compactResult = new
+                {
+                    symbol = result.Symbol?.FullyQualifiedName ?? "unknown",
+                    count = result.TotalFound,
+                    refs = compactRefs
+                };
+
                 return new
                 {
                     content = new[]
                     {
-                        new { type = "text", text = JsonSerializer.Serialize(result, JsonOptions) }
+                        new { type = "text", text = JsonSerializer.Serialize(compactResult, JsonOptions) }
                     },
-                    isError = !result.Success
+                    isError = false
                 };
             });
     }

--- a/src/RoslynTools.TypeMembers.cs
+++ b/src/RoslynTools.TypeMembers.cs
@@ -102,14 +102,81 @@ public static partial class RoslynTools
                 if (result.Success)
                     LastSymbolTracker.Track(solutionPath!, typeName, "type");
 
+                if (!result.Success)
+                {
+                    return new
+                    {
+                        content = new[]
+                        {
+                            new { type = "text", text = JsonSerializer.Serialize(result, JsonOptions) }
+                        },
+                        isError = true
+                    };
+                }
+
+                // Build compact response - group by kind
+                var fields = result.Members
+                    .Where(m => m.Kind == "Field")
+                    .Select(m => FormatMemberCompact(m))
+                    .ToList();
+
+                var properties = result.Members
+                    .Where(m => m.Kind == "Property")
+                    .Select(m => FormatMemberCompact(m))
+                    .ToList();
+
+                var methods = result.Members
+                    .Where(m => m.Kind == "Method")
+                    .Select(m => FormatMemberCompact(m))
+                    .ToList();
+
+                var constructors = result.Members
+                    .Where(m => m.Kind == "Constructor")
+                    .Select(m => FormatMemberCompact(m))
+                    .ToList();
+
+                var events = result.Members
+                    .Where(m => m.Kind == "Event")
+                    .Select(m => FormatMemberCompact(m))
+                    .ToList();
+
+                var compactResult = new Dictionary<string, object>
+                {
+                    ["type"] = result.Type?.FullyQualifiedName ?? typeName,
+                    ["count"] = result.TotalMembers
+                };
+
+                // Only include non-empty groups
+                if (fields.Count > 0) compactResult["fields"] = fields;
+                if (properties.Count > 0) compactResult["properties"] = properties;
+                if (constructors.Count > 0) compactResult["constructors"] = constructors;
+                if (methods.Count > 0) compactResult["methods"] = methods;
+                if (events.Count > 0) compactResult["events"] = events;
+
                 return new
                 {
                     content = new[]
                     {
-                        new { type = "text", text = JsonSerializer.Serialize(result, JsonOptions) }
+                        new { type = "text", text = JsonSerializer.Serialize(compactResult, JsonOptions) }
                     },
-                    isError = !result.Success
+                    isError = false
                 };
             });
     }
+
+    private static string FormatMemberCompact(MemberInfo member)
+    {
+        var sig = member.Signature;
+
+        // For properties, remove the { get; set; } part
+        if (member.Kind == "Property")
+        {
+            var braceIndex = sig.IndexOf('{');
+            if (braceIndex > 0)
+                sig = sig.Substring(0, braceIndex).Trim();
+        }
+
+        return sig;
+    }
+
 }

--- a/src/RoslynTools.UpdateMethod.cs
+++ b/src/RoslynTools.UpdateMethod.cs
@@ -64,40 +64,13 @@ public static partial class RoslynTools
                 var parameterTypes = args?["parameterTypes"]?.GetValue<string>();
 
                 if (string.IsNullOrWhiteSpace(typeName))
-                {
-                    return new
-                    {
-                        content = new[]
-                        {
-                            new { type = "text", text = "Error: typeName is required" }
-                        },
-                        isError = true
-                    };
-                }
+                    return CreateToolError("Error: typeName is required");
 
                 if (string.IsNullOrWhiteSpace(methodName))
-                {
-                    return new
-                    {
-                        content = new[]
-                        {
-                            new { type = "text", text = "Error: methodName is required" }
-                        },
-                        isError = true
-                    };
-                }
+                    return CreateToolError("Error: methodName is required");
 
                 if (string.IsNullOrWhiteSpace(newSourceCode))
-                {
-                    return new
-                    {
-                        content = new[]
-                        {
-                            new { type = "text", text = "Error: newSourceCode is required" }
-                        },
-                        isError = true
-                    };
-                }
+                    return CreateToolError("Error: newSourceCode is required");
 
                 var result = await SolutionAnalyzerService.UpdateMethodAsync(
                     solutionPath!,
@@ -106,14 +79,29 @@ public static partial class RoslynTools
                     newSourceCode,
                     parameterTypes);
 
-                return new
+                if (!result.Success)
                 {
-                    content = new[]
+                    var errorResponse = new Dictionary<string, object?>
                     {
-                        new { type = "text", text = JsonSerializer.Serialize(result, JsonOptions) }
-                    },
-                    isError = !result.Success
+                        ["error"] = result.Error
+                    };
+                    if (result.AvailableOverloads != null && result.AvailableOverloads.Count > 0)
+                    {
+                        errorResponse["availableOverloads"] = result.AvailableOverloads;
+                    }
+                    return CreateToolResponse(errorResponse, true);
+                }
+
+                // Compact success response
+                var relativePath = GetRelativePath(result.FilePath ?? "", solutionPath!);
+                var compactResult = new
+                {
+                    file = $"{relativePath}:{result.StartLine}-{result.EndLine}",
+                    oldSignature = result.OldSignature,
+                    newSignature = result.NewSignature
                 };
+
+                return CreateToolResponse(compactResult, false);
             });
     }
 


### PR DESCRIPTION
## Summary
- Remove redundant wrapper fields (`success`, `error`, `solutionPath`) from tool responses
- Group members by kind in `roslyn_get_type_members`
- Use compact string format: `"Symbol (Kind) path:line"`

## Before/After Example

**roslyn_find_symbol before:**
```json
{
  "success": true,
  "error": null,
  "solutionPath": "C:\...\RoslynMcpServer.slnx",
  "pattern": "RoslynTools",
  "totalFound": 1,
  "symbols": [{ "name": "RoslynTools", "fullyQualifiedName": "...", "kind": "Class", "filePath": "...", "line": 5 }]
}
```

**roslyn_find_symbol after:**
```json
{
  "count": 1,
  "symbols": ["RoslynMcpServer.RoslynTools (Class) src\RoslynTools.AddMember.cs:5"]
}
```

## Optimized Tools
- `roslyn_find_symbol`
- `roslyn_get_type_members`
- `roslyn_get_callers`
- `roslyn_get_references`
- `roslyn_get_implementations`
- `roslyn_get_method_body`
- `roslyn_get_diagnostics`
- `roslyn_graph_status`
- `roslyn_graph_analyze`
- `roslyn_query_graph`
- `roslyn_graph_impact`
- `roslyn_update_method`

## Test plan
- [x] All 109 tests pass
- [x] Manual testing of compact output format

🤖 Generated with [Claude Code](https://claude.com/claude-code)