### PR TITLE
Remove solutionPath parameter from all MCP tools

### DIFF
--- a/src/RoslynTools.AddMember.cs
+++ b/src/RoslynTools.AddMember.cs
@@ -22,11 +22,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         typeName = new
                         {
                             type = "string",
@@ -41,10 +36,10 @@ public static partial class RoslynTools
                         {
                             type = "string",
                             description = "Where to insert: 'start', 'end', 'after-fields', 'after-constructors', 'after-properties', 'before-methods'. Default: smart placement based on member type.",
-                            @enum = definition
+                            @enum = new[] { "start", "end", "after-fields", "after-constructors", "after-properties", "before-methods" }
                         }
                     },
-                    required = definitionArray
+                    required = new[] { "typeName", "memberCode" }
                 },
                 Annotations = new ToolAnnotations
                 {
@@ -54,22 +49,12 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
+
                 var typeName = args?["typeName"]?.GetValue<string>();
                 var memberCode = args?["memberCode"]?.GetValue<string>();
                 var insertionPoint = args?["insertionPoint"]?.GetValue<string>();
-
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                {
-                    return new
-                    {
-                        content = new[]
-                        {
-                            new { type = "text", text = "Error: solutionPath is required" }
-                        },
-                        isError = true
-                    };
-                }
 
                 if (string.IsNullOrWhiteSpace(typeName))
                 {
@@ -96,7 +81,7 @@ public static partial class RoslynTools
                 }
 
                 var result = await SolutionAnalyzerService.AddMemberAsync(
-                    solutionPath,
+                    solutionPath!,
                     typeName,
                     memberCode,
                     insertionPoint);

--- a/src/RoslynTools.AddType.cs
+++ b/src/RoslynTools.AddType.cs
@@ -24,11 +24,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         projectName = new
                         {
                             type = "string",
@@ -43,7 +38,7 @@ public static partial class RoslynTools
                         {
                             type = "string",
                             description = "Kind of type to create: 'class', 'interface', 'struct', 'record', 'enum'. Default: 'class'",
-                            @enum = definitionArray6
+                            @enum = new[] { "class", "interface", "struct", "record", "enum" }
                         },
                         @namespace = new
                         {
@@ -59,7 +54,7 @@ public static partial class RoslynTools
                         {
                             type = "string",
                             description = "Access modifier: 'public', 'internal', 'private', 'protected'. Default: 'public'",
-                            @enum = definitionArray7
+                            @enum = new[] { "public", "internal", "private", "protected" }
                         },
                         baseTypes = new
                         {
@@ -82,7 +77,7 @@ public static partial class RoslynTools
                             description = "Create as static (classes only). Default: false"
                         }
                     },
-                    required = definitionArray8
+                    required = new[] { "projectName", "typeName" }
                 },
                 Annotations = new ToolAnnotations
                 {

--- a/src/RoslynTools.BatchCodeFix.cs
+++ b/src/RoslynTools.BatchCodeFix.cs
@@ -20,11 +20,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         diagnosticId = new
                         {
                             type = "string",
@@ -53,7 +48,7 @@ public static partial class RoslynTools
                             description = "If true, returns what would change without actually applying fixes. Default: false"
                         }
                     },
-                    required = definitionArray9
+                    required = new[] { "diagnosticId" }
                 },
                 Annotations = new ToolAnnotations
                 {

--- a/src/RoslynTools.Callers.cs
+++ b/src/RoslynTools.Callers.cs
@@ -24,11 +24,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         filePath = new
                         {
                             type = "string",
@@ -70,7 +65,7 @@ public static partial class RoslynTools
                             description = "Filter by file path. Supports wildcards (*). Example: '*Service.cs'"
                         }
                     },
-                    required = definitionArray1
+                    required = new[] { "filePath", "line", "column" }
                 },
                 Annotations = new ToolAnnotations
                 {

--- a/src/RoslynTools.CodeFix.cs
+++ b/src/RoslynTools.CodeFix.cs
@@ -24,11 +24,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         filePath = new
                         {
                             type = "string",
@@ -65,7 +60,7 @@ public static partial class RoslynTools
                             description = "If true, returns what would change without actually applying the fix. Default: false"
                         }
                     },
-                    required = definitionArray10
+                    required = new[] { "filePath", "line", "column" }
                 },
                 Annotations = new ToolAnnotations
                 {

--- a/src/RoslynTools.DeleteMember.cs
+++ b/src/RoslynTools.DeleteMember.cs
@@ -23,11 +23,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         typeName = new
                         {
                             type = "string",
@@ -42,7 +37,7 @@ public static partial class RoslynTools
                         {
                             type = "string",
                             description = "Kind of member: 'method', 'property', 'field'. Optional - used to disambiguate when multiple members have the same name.",
-                            @enum = definitionArray13
+                            @enum = new[] { "method", "property", "field" }
                         },
                         parameterTypes = new
                         {
@@ -50,7 +45,7 @@ public static partial class RoslynTools
                             description = "Parameter types for method overloads, e.g. 'string, int'. Required if multiple method overloads exist."
                         }
                     },
-                    required = definitionArray14
+                    required = new[] { "typeName", "memberName" }
                 },
                 Annotations = new ToolAnnotations
                 {

--- a/src/RoslynTools.Diagnostics.cs
+++ b/src/RoslynTools.Diagnostics.cs
@@ -22,11 +22,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         diagnosticId = new
                         {
                             type = "string",
@@ -36,7 +31,7 @@ public static partial class RoslynTools
                         {
                             type = "string",
                             description = "Filter by severity: 'error', 'warning', 'info', or 'all'. Default: 'all'",
-                            @enum = definitionArray15
+                            @enum = new[] { "all", "error", "warning", "info" }
                         },
                         projectFilter = new
                         {
@@ -57,7 +52,7 @@ public static partial class RoslynTools
                             minimum = 0
                         }
                     },
-                    required = definitionArray16
+                    required = Array.Empty<string>()
                 },
                 Annotations = new ToolAnnotations
                 {

--- a/src/RoslynTools.ExtractMethod.cs
+++ b/src/RoslynTools.ExtractMethod.cs
@@ -22,11 +22,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         filePath = new
                         {
                             type = "string",
@@ -53,10 +48,10 @@ public static partial class RoslynTools
                         {
                             type = "string",
                             description = "Access modifier for the new method. Default: 'private'",
-                            @enum = definitionArray17
+                            @enum = new[] { "private", "internal", "protected", "public" }
                         }
                     },
-                    required = definitionArray18
+                    required = new[] { "filePath", "startLine", "endLine", "methodName" }
                 },
                 Annotations = new ToolAnnotations
                 {

--- a/src/RoslynTools.FindSymbol.cs
+++ b/src/RoslynTools.FindSymbol.cs
@@ -24,11 +24,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         pattern = new
                         {
                             type = "string",
@@ -38,13 +33,13 @@ public static partial class RoslynTools
                         {
                             type = "string",
                             description = "Kind of symbols to find: 'all', 'type', 'member', 'namespace', 'typeAndMember'. Default: 'all'",
-                            @enum = definitionArray19
+                            @enum = new[] { "all", "type", "member", "namespace", "typeAndMember" }
                         },
                         matchType = new
                         {
                             type = "string",
                             description = "How to match the pattern: 'exact', 'exactIgnoreCase', 'contains', 'prefix', 'suffix'. Default: 'contains'",
-                            @enum = definitionArray20
+                            @enum = new[] { "exact", "exactIgnoreCase", "contains", "prefix", "suffix" }
                         },
                         maxResults = new
                         {
@@ -59,7 +54,7 @@ public static partial class RoslynTools
                             description = "Return minimal fields only (name, qualifiedName, kind, file, line). Default: true. Set to false for detailed info (column, containingType, accessibility, isStatic, signature)"
                         }
                     },
-                    required = definitionArray21
+                    required = new[] { "pattern" }
                 },
                 Annotations = new ToolAnnotations
                 {

--- a/src/RoslynTools.Graph.cs
+++ b/src/RoslynTools.Graph.cs
@@ -21,15 +21,8 @@ public static partial class RoslynTools
                 InputSchema = new
                 {
                     type = "object",
-                    properties = new
-                    {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        }
-                    },
-                    required = definitionArray22
+                    properties = new { },
+                    required = Array.Empty<string>()
                 },
                 Annotations = new ToolAnnotations
                 {
@@ -81,11 +74,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         incremental = new
                         {
                             type = "boolean",
@@ -97,7 +85,7 @@ public static partial class RoslynTools
                             description = "Optional: filter by project name (partial match)"
                         }
                     },
-                    required = definitionArray23
+                    required = Array.Empty<string>()
                 },
                 Annotations = new ToolAnnotations
                 {
@@ -147,11 +135,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         symbolName = new
                         {
                             type = "string",
@@ -161,7 +144,7 @@ public static partial class RoslynTools
                         {
                             type = "string",
                             description = "Query direction: 'callers', 'callees', or 'both'. Default: 'both'",
-                            @enum = definitionArray24
+                            @enum = new[] { "callers", "callees", "both" }
                         },
                         maxDepth = new
                         {
@@ -171,7 +154,7 @@ public static partial class RoslynTools
                             maximum = 100
                         }
                     },
-                    required = definitionArray25
+                    required = new[] { "symbolName" }
                 },
                 Annotations = new ToolAnnotations
                 {

--- a/src/RoslynTools.GraphImpact.cs
+++ b/src/RoslynTools.GraphImpact.cs
@@ -23,11 +23,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         symbolName = new
                         {
                             type = "string",
@@ -46,7 +41,7 @@ public static partial class RoslynTools
                             description = "Include test files in impact analysis. Default: true"
                         }
                     },
-                    required = definitionArray0
+                    required = new[] { "symbolName" }
                 },
                 Annotations = new ToolAnnotations
                 {
@@ -111,11 +106,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         includePrivate = new
                         {
                             type = "boolean",
@@ -146,7 +136,7 @@ public static partial class RoslynTools
                             description = "Additional file path patterns to exclude (contains match). Example: ['Models/', 'Dto/']. Empty by default - relies on structural detection instead."
                         }
                     },
-                    required = definitionArray100
+                    required = Array.Empty<string>()
                 },
                 Annotations = new ToolAnnotations
                 {

--- a/src/RoslynTools.Implementations.cs
+++ b/src/RoslynTools.Implementations.cs
@@ -21,11 +21,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         typeName = new
                         {
                             type = "string",
@@ -44,7 +39,7 @@ public static partial class RoslynTools
                             maximum = 1000
                         }
                     },
-                    required = definitionArray26
+                    required = new[] { "typeName" }
                 },
                 Annotations = new ToolAnnotations
                 {

--- a/src/RoslynTools.Knowledge.cs
+++ b/src/RoslynTools.Knowledge.cs
@@ -45,11 +45,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         category = new
                         {
                             type = "string",
@@ -86,7 +81,7 @@ public static partial class RoslynTools
                             maximum = 1.0
                         }
                     },
-                    required = definitionArrayKnowledge
+                    required = new[] { "category", "title", "content" }
                 },
                 Annotations = new ToolAnnotations
                 {
@@ -177,11 +172,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         query = new
                         {
                             type = "string",
@@ -266,11 +256,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         category = new
                         {
                             type = "string",
@@ -361,11 +346,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         id = new
                         {
                             type = "integer",
@@ -430,11 +410,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         id = new
                         {
                             type = "integer",
@@ -508,11 +483,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         symbolName = new
                         {
                             type = "string",

--- a/src/RoslynTools.MethodBody.cs
+++ b/src/RoslynTools.MethodBody.cs
@@ -21,11 +21,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         typeName = new
                         {
                             type = "string",
@@ -42,7 +37,7 @@ public static partial class RoslynTools
                             description = "Parameter types to identify a specific overload, e.g. 'string, int' or 'CancellationToken, bool'. Required if multiple overloads exist."
                         }
                     },
-                    required = definitionArray27
+                    required = new[] { "typeName", "methodName" }
                 },
                 Annotations = new ToolAnnotations
                 {

--- a/src/RoslynTools.References.cs
+++ b/src/RoslynTools.References.cs
@@ -21,11 +21,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         filePath = new
                         {
                             type = "string",
@@ -61,7 +56,7 @@ public static partial class RoslynTools
                             description = "Filter by file path. Supports wildcards (*). Example: '*Controller.cs' or 'Services'"
                         }
                     },
-                    required = definitionArray28
+                    required = new[] { "filePath", "line", "column" }
                 },
                 Annotations = new ToolAnnotations
                 {

--- a/src/RoslynTools.RemoveUsings.cs
+++ b/src/RoslynTools.RemoveUsings.cs
@@ -19,11 +19,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         projectFilter = new
                         {
                             type = "string",

--- a/src/RoslynTools.Rename.cs
+++ b/src/RoslynTools.Rename.cs
@@ -19,11 +19,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         filePath = new
                         {
                             type = "string",
@@ -47,7 +42,7 @@ public static partial class RoslynTools
                             description = "The new name for the symbol"
                         }
                     },
-                    required = definitionArray29
+                    required = new[] { "filePath", "line", "column", "newName" }
                 },
                 Annotations = new ToolAnnotations
                 {

--- a/src/RoslynTools.TypeMembers.cs
+++ b/src/RoslynTools.TypeMembers.cs
@@ -22,11 +22,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         typeName = new
                         {
                             type = "string",
@@ -36,7 +31,7 @@ public static partial class RoslynTools
                         {
                             type = "string",
                             description = "Filter by member kind: 'all', 'methods', 'properties', 'fields', 'events', 'constructors'. Default: 'all'",
-                            @enum = definitionArray32
+                            @enum = new[] { "all", "methods", "properties", "fields", "events", "constructors" }
                         },
                         includeInherited = new
                         {
@@ -49,7 +44,7 @@ public static partial class RoslynTools
                             description = "Return minimal fields only (name, kind, signature). Default: true. Set to false for detailed info (filePath, line, accessibility, isStatic, etc.)"
                         }
                     },
-                    required = definitionArray33
+                    required = new[] { "typeName" }
                 },
                 Annotations = new ToolAnnotations
                 {

--- a/src/RoslynTools.UpdateMethod.cs
+++ b/src/RoslynTools.UpdateMethod.cs
@@ -19,11 +19,6 @@ public static partial class RoslynTools
                     type = "object",
                     properties = new
                     {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        },
                         typeName = new
                         {
                             type = "string",
@@ -45,7 +40,7 @@ public static partial class RoslynTools
                             description = "Parameter types to identify a specific overload, e.g. 'string, int'. Required if multiple overloads exist."
                         }
                     },
-                    required = definitionArray34
+                    required = new[] { "typeName", "methodName", "newSourceCode" }
                 },
                 Annotations = new ToolAnnotations
                 {

--- a/src/RoslynTools.cs
+++ b/src/RoslynTools.cs
@@ -207,15 +207,8 @@ public static partial class RoslynTools
                 InputSchema = new
                 {
                     type = "object",
-                    properties = new
-                    {
-                        solutionPath = new
-                        {
-                            type = "string",
-                            description = "Absolute path to the .sln or .slnx solution file"
-                        }
-                    },
-                    required = definitionArray12
+                    properties = new { },
+                    required = Array.Empty<string>()
                 },
                 Annotations = new ToolAnnotations
                 {
@@ -225,21 +218,10 @@ public static partial class RoslynTools
             },
             async args =>
             {
-                var solutionPath = args?["solutionPath"]?.GetValue<string>();
+                var (solutionPath, solutionError) = GetSolutionPathOrError();
+                if (solutionError != null) return solutionError;
 
-                if (string.IsNullOrWhiteSpace(solutionPath))
-                {
-                    return new
-                    {
-                        content = new[]
-                        {
-                            new { type = "text", text = "Error: solutionPath is required" }
-                        },
-                        isError = true
-                    };
-                }
-
-                var result = await _analyzerService!.GetProjectsInBuildOrderAsync(solutionPath);
+                var result = await _analyzerService!.GetProjectsInBuildOrderAsync(solutionPath!);
 
                 return new
                 {


### PR DESCRIPTION
## Summary
- Removed redundant `solutionPath` parameter from all 20 MCP tool definitions
- The parameter was unnecessary since the server auto-detects the solution at startup
- Handlers already use `GetSolutionPathOrError()` for the cached solution path

## Test plan
- [x] Build succeeds with no warnings
- [x] All 109 tests pass

Fixes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)