### PR TITLE
Feature: Add edit mode to UpdateMethod tool

### DIFF
--- a/Instructions/Topics/tools.md
+++ b/Instructions/Topics/tools.md
@@ -9,7 +9,8 @@ Hook blocks Read/Edit on .cs files. Use Roslyn tools instead.
 | Find symbol | `FindSymbol(pattern)` |
 | See class structure | `GetTypeMembers(typeName)` |
 | Read method | `GetMethodBody(typeName, methodName)` |
-| Edit method | `UpdateMethod(typeName, methodName, newSourceCode, comment?)` |
+| Edit method (full) | `UpdateMethod(typeName, methodName, newSourceCode, comment?)` |
+| Edit method (targeted) | `UpdateMethod(typeName, methodName, oldText, newText, replaceAll?)` |
 | Add member | `AddMember(typeName, memberCode, auto?, comment?)` |
 | Create type | `AddType(projectName, typeName)` |
 | Delete member | `DeleteMember(typeName, memberName)` |
@@ -63,11 +64,16 @@ Call `Finetune()` again to check status. See [SharpOps/WORKFLOW.md](../../../Sha
 
 ## Patterns
 
-**Explore class → edit method:**
+**Explore class → edit method (full replacement):**
 ```
 GetTypeMembers(typeName)
 GetMethodBody(typeName, methodName)
 UpdateMethod(typeName, methodName, newCode)
+```
+
+**Targeted edit within a method:**
+```
+UpdateMethod(typeName, methodName, oldText: "oldCode", newText: "newCode")
 ```
 
 **Create new type with members:**

--- a/RoslynMcpServer.Tests/Services/UpdateMethodEditModeTests.cs
+++ b/RoslynMcpServer.Tests/Services/UpdateMethodEditModeTests.cs
@@ -1,0 +1,296 @@
+namespace RoslynMcpServer.Tests.Services;
+
+/// <summary>
+/// Tests for UpdateMethod edit mode (oldText/newText).
+/// Issue: #127
+/// </summary>
+public class UpdateMethodEditModeTests : IAsyncLifetime
+{
+    private string _tempDir = "";
+    private string _solutionPath = "";
+    private string _projectPath = "";
+    private string _sourceFilePath = "";
+
+    public async Task InitializeAsync()
+    {
+        _tempDir = Path.Combine(Path.GetTempPath(), $"UpdateMethodEditTest_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_tempDir);
+
+        _solutionPath = Path.Combine(_tempDir, "Test.sln");
+        _projectPath = Path.Combine(_tempDir, "Test.csproj");
+        _sourceFilePath = Path.Combine(_tempDir, "Calculator.cs");
+
+        await File.WriteAllTextAsync(_solutionPath, """
+            Microsoft Visual Studio Solution File, Format Version 12.00
+            Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test", "Test.csproj", "{12345678-1234-1234-1234-123456789012}"
+            EndProject
+            """);
+
+        await File.WriteAllTextAsync(_projectPath, """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net8.0</TargetFramework>
+                <Nullable>enable</Nullable>
+              </PropertyGroup>
+            </Project>
+            """);
+    }
+
+    public Task DisposeAsync()
+    {
+        if (Directory.Exists(_tempDir))
+        {
+            try { Directory.Delete(_tempDir, true); }
+            catch { /* Ignore cleanup errors */ }
+        }
+        return Task.CompletedTask;
+    }
+
+    private async Task WriteTestClass(string source)
+    {
+        await File.WriteAllTextAsync(_sourceFilePath, source);
+    }
+
+    [Fact]
+    public async Task EditMode_SingleOccurrence_ReplacesText()
+    {
+        await WriteTestClass("""
+            namespace Test;
+
+            public class Calculator
+            {
+                public int Add(int a, int b)
+                {
+                    return a + b;
+                }
+            }
+            """);
+
+        var result = await SolutionAnalyzerService.UpdateMethodAsync(
+            _solutionPath,
+            "Calculator",
+            "Add",
+            newSourceCode: null,
+            oldText: "return a + b;",
+            newText: "return a + b + 0;");
+
+        Assert.True(result.Success, result.Error);
+
+        var content = await File.ReadAllTextAsync(_sourceFilePath);
+        Assert.Contains("return a + b + 0;", content);
+        Assert.DoesNotContain("return a + b;", content);
+    }
+
+    [Fact]
+    public async Task EditMode_Deletion_RemovesText()
+    {
+        await WriteTestClass("""
+            namespace Test;
+
+            public class Calculator
+            {
+                public int Add(int a, int b)
+                {
+                    // TODO: remove this comment
+                    return a + b;
+                }
+            }
+            """);
+
+        var result = await SolutionAnalyzerService.UpdateMethodAsync(
+            _solutionPath,
+            "Calculator",
+            "Add",
+            newSourceCode: null,
+            oldText: "// TODO: remove this comment",
+            newText: "");
+
+        Assert.True(result.Success, result.Error);
+
+        var content = await File.ReadAllTextAsync(_sourceFilePath);
+        Assert.DoesNotContain("TODO", content);
+        Assert.Contains("return a + b;", content);
+    }
+
+    [Fact]
+    public async Task EditMode_MultilineReplacement_Works()
+    {
+        await WriteTestClass("""
+            namespace Test;
+
+            public class Calculator
+            {
+                public int Add(int a, int b)
+                {
+                    return a + b;
+                }
+            }
+            """);
+
+        var result = await SolutionAnalyzerService.UpdateMethodAsync(
+            _solutionPath,
+            "Calculator",
+            "Add",
+            newSourceCode: null,
+            oldText: "return a + b;",
+            newText: """
+                var result = a + b;
+                        return result;
+                """);
+
+        Assert.True(result.Success, result.Error);
+
+        var content = await File.ReadAllTextAsync(_sourceFilePath);
+        Assert.Contains("var result = a + b;", content);
+        Assert.Contains("return result;", content);
+    }
+
+    [Fact]
+    public async Task EditMode_OldTextNotFound_ReturnsError()
+    {
+        await WriteTestClass("""
+            namespace Test;
+
+            public class Calculator
+            {
+                public int Add(int a, int b)
+                {
+                    return a + b;
+                }
+            }
+            """);
+
+        var result = await SolutionAnalyzerService.UpdateMethodAsync(
+            _solutionPath,
+            "Calculator",
+            "Add",
+            newSourceCode: null,
+            oldText: "this text does not exist",
+            newText: "replacement");
+
+        Assert.False(result.Success);
+        Assert.Contains("oldText not found", result.Error);
+    }
+
+    [Fact]
+    public async Task EditMode_MultipleOccurrences_WithoutReplaceAll_ReturnsError()
+    {
+        await WriteTestClass("""
+            namespace Test;
+
+            public class Calculator
+            {
+                public int Add(int a, int b)
+                {
+                    var x = a + b;
+                    var y = a + b;
+                    return x + y;
+                }
+            }
+            """);
+
+        var result = await SolutionAnalyzerService.UpdateMethodAsync(
+            _solutionPath,
+            "Calculator",
+            "Add",
+            newSourceCode: null,
+            oldText: "a + b",
+            newText: "a - b");
+
+        Assert.False(result.Success);
+        Assert.Contains("2 times", result.Error);
+        Assert.Contains("replaceAll", result.Error);
+    }
+
+    [Fact]
+    public async Task EditMode_MultipleOccurrences_WithReplaceAll_ReplacesAll()
+    {
+        await WriteTestClass("""
+            namespace Test;
+
+            public class Calculator
+            {
+                public int Add(int a, int b)
+                {
+                    var x = a + b;
+                    var y = a + b;
+                    return x + y;
+                }
+            }
+            """);
+
+        var result = await SolutionAnalyzerService.UpdateMethodAsync(
+            _solutionPath,
+            "Calculator",
+            "Add",
+            newSourceCode: null,
+            oldText: "a + b",
+            newText: "a - b",
+            replaceAll: true);
+
+        Assert.True(result.Success, result.Error);
+
+        var content = await File.ReadAllTextAsync(_sourceFilePath);
+        Assert.DoesNotContain("a + b", content);
+        // Both occurrences replaced
+        var count = content.Split("a - b").Length - 1;
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public async Task EditMode_PreservesMethodSignature()
+    {
+        await WriteTestClass("""
+            namespace Test;
+
+            public class Calculator
+            {
+                public int Add(int a, int b)
+                {
+                    return a + b;
+                }
+            }
+            """);
+
+        var result = await SolutionAnalyzerService.UpdateMethodAsync(
+            _solutionPath,
+            "Calculator",
+            "Add",
+            newSourceCode: null,
+            oldText: "return a + b;",
+            newText: "return a + b + 1;");
+
+        Assert.True(result.Success, result.Error);
+        Assert.Equal("int Add(int a, int b)", result.OldSignature);
+
+        var content = await File.ReadAllTextAsync(_sourceFilePath);
+        Assert.Contains("public int Add(int a, int b)", content);
+    }
+
+    [Fact]
+    public async Task EditMode_MethodNotFound_ReturnsError()
+    {
+        await WriteTestClass("""
+            namespace Test;
+
+            public class Calculator
+            {
+                public int Add(int a, int b)
+                {
+                    return a + b;
+                }
+            }
+            """);
+
+        var result = await SolutionAnalyzerService.UpdateMethodAsync(
+            _solutionPath,
+            "Calculator",
+            "NonExistent",
+            newSourceCode: null,
+            oldText: "something",
+            newText: "other");
+
+        Assert.False(result.Success);
+        Assert.Contains("not found", result.Error);
+    }
+}

--- a/src/RoslynTools.UpdateMethod.cs
+++ b/src/RoslynTools.UpdateMethod.cs
@@ -5,15 +5,16 @@ namespace RoslynMcpServer;
 public static partial class RoslynTools
 {
     /// <summary>
-    /// Updates a method's source code in place.
+    /// Registers the UpdateMethod tool with MCP server. Supports two modes: full replacement via newSourceCode, or targeted edit via oldText/newText parameters.
     /// </summary>
+    /// <param name="server"></param>
     private static void RegisterUpdateMethodTool(McpServer server)
     {
         server.RegisterTool(
             "UpdateMethod",
             new ToolDefinition
             {
-                Description = "Replaces a method's implementation with new source code. Uses Roslyn to precisely locate and replace the method while preserving surrounding code. Essential for making targeted changes to large classes.",
+                Description = "Replaces a method's implementation with new source code. Uses Roslyn to precisely locate and replace the method while preserving surrounding code. Essential for making targeted changes to large classes.\n\nSupports two modes:\n1. Full replacement: provide `newSourceCode` with the complete method\n2. Edit mode: provide `oldText` + `newText` to make targeted edits within the method (token-efficient)",
                 InputSchema = new
                 {
                     type = "object",
@@ -43,9 +44,24 @@ public static partial class RoslynTools
                         {
                             type = "string",
                             description = "Plain text description of the method. Generates XML doc comment with <summary>, <param>, and <returns> tags, replacing any existing XML doc."
+                        },
+                        oldText = new
+                        {
+                            type = "string",
+                            description = "Text to find within the current method source. Use with newText for targeted edits instead of full replacement."
+                        },
+                        newText = new
+                        {
+                            type = "string",
+                            description = "Replacement text (can be empty string for deletion). Required when oldText is provided."
+                        },
+                        replaceAll = new
+                        {
+                            type = "boolean",
+                            description = "Replace all occurrences of oldText. Default: false (errors if multiple matches found)."
                         }
                     },
-                    required = new[] { "typeName", "methodName", "newSourceCode" }
+                    required = new[] { "typeName", "methodName" }
                 },
                 Annotations = new ToolAnnotations
                 {
@@ -63,6 +79,9 @@ public static partial class RoslynTools
                 var newSourceCode = args?["newSourceCode"]?.GetValue<string>();
                 var parameterTypes = args?["parameterTypes"]?.GetValue<string>();
                 var comment = args?["comment"]?.GetValue<string>();
+                var oldText = args?["oldText"]?.GetValue<string>();
+                var newText = args?["newText"]?.GetValue<string>();
+                var replaceAll = GetOptionalBool(args, "replaceAll", false);
 
                 if (string.IsNullOrWhiteSpace(typeName))
                     return CreateToolError("Error: typeName is required");
@@ -70,8 +89,18 @@ public static partial class RoslynTools
                 if (string.IsNullOrWhiteSpace(methodName))
                     return CreateToolError("Error: methodName is required");
 
-                if (string.IsNullOrWhiteSpace(newSourceCode))
-                    return CreateToolError("Error: newSourceCode is required");
+                // Validate: either newSourceCode or oldText+newText, not both
+                if (!string.IsNullOrEmpty(newSourceCode) && oldText != null)
+                    return CreateToolError("Error: cannot provide both newSourceCode and oldText/newText. Use one mode or the other.");
+
+                if (oldText != null && newText == null)
+                    return CreateToolError("Error: newText is required when oldText is provided (can be empty string for deletion).");
+
+                if (oldText == null && newText != null)
+                    return CreateToolError("Error: oldText is required when newText is provided.");
+
+                if (string.IsNullOrEmpty(newSourceCode) && oldText == null)
+                    return CreateToolError("Error: provide either newSourceCode (full replacement) or oldText+newText (edit mode).");
 
                 var result = await SolutionAnalyzerService.UpdateMethodAsync(
                     solutionPath!,
@@ -79,7 +108,10 @@ public static partial class RoslynTools
                     methodName,
                     newSourceCode,
                     parameterTypes,
-                    comment);
+                    comment,
+                    oldText,
+                    newText,
+                    replaceAll);
 
                 if (!result.Success)
                 {

--- a/src/SolutionAnalyzerService.UpdateMethod.cs
+++ b/src/SolutionAnalyzerService.UpdateMethod.cs
@@ -8,13 +8,29 @@ namespace RoslynMcpServer;
 
 public partial class SolutionAnalyzerService
 {
+    /// <summary>
+    /// Updates a method's source code. Supports full replacement via newSourceCode, or targeted edit mode via oldText/newText parameters that perform text replacement within the existing method body.
+    /// </summary>
+    /// <param name="solutionPath"></param>
+    /// <param name="typeName"></param>
+    /// <param name="methodName"></param>
+    /// <param name="newSourceCode"></param>
+    /// <param name="parameterTypes"></param>
+    /// <param name="comment"></param>
+    /// <param name="oldText"></param>
+    /// <param name="newText"></param>
+    /// <param name="replaceAll"></param>
+    /// <returns></returns>
     public static async Task<UpdateMethodResult> UpdateMethodAsync(
     string solutionPath,
     string typeName,
     string methodName,
-    string newSourceCode,
+    string? newSourceCode,
     string? parameterTypes = null,
-    string? comment = null)
+    string? comment = null,
+    string? oldText = null,
+    string? newText = null,
+    bool replaceAll = false)
     {
         EnsureMSBuildRegistered();
 
@@ -163,8 +179,51 @@ public partial class SolutionAnalyzerService
                 };
             }
 
+            // Edit mode: perform oldText -> newText replacement within the method
+            if (oldText != null && newText != null)
+            {
+                var currentSource = methodNode.ToFullString();
+                var occurrences = 0;
+                var idx = -1;
+                var searchFrom = 0;
+                while ((idx = currentSource.IndexOf(oldText, searchFrom, StringComparison.Ordinal)) >= 0)
+                {
+                    occurrences++;
+                    searchFrom = idx + oldText.Length;
+                }
+
+                if (occurrences == 0)
+                {
+                    return new UpdateMethodResult
+                    {
+                        Success = false,
+                        Error = $"oldText not found in method '{methodName}'. The text to find was:\n{oldText}"
+                    };
+                }
+
+                if (occurrences > 1 && !replaceAll)
+                {
+                    return new UpdateMethodResult
+                    {
+                        Success = false,
+                        Error = $"oldText found {occurrences} times in method '{methodName}'. Set replaceAll=true to replace all, or provide more context to make the match unique."
+                    };
+                }
+
+                if (replaceAll)
+                {
+                    newSourceCode = currentSource.Replace(oldText, newText, StringComparison.Ordinal);
+                }
+                else
+                {
+                    // Single occurrence - replace first match
+                    var pos = currentSource.IndexOf(oldText, StringComparison.Ordinal);
+                    newSourceCode = string.Concat(currentSource.AsSpan(0, pos), newText, currentSource.AsSpan(pos + oldText.Length));
+                }
+            }
+
             // Parse the new source code
-            var newSyntaxTree = CSharpSyntaxTree.ParseText(newSourceCode.Trim());
+            var newSyntaxTree = CSharpSyntaxTree.ParseText(newSourceCode!.Trim());
             var newRoot = await newSyntaxTree.GetRootAsync();
 
             // Find the method declaration in the new code
@@ -215,7 +274,7 @@ public partial class SolutionAnalyzerService
             // Add XML doc comment AFTER setting trivia, so it doesn't get overwritten
             if (comment != null && newMethodWithTrivia is MemberDeclarationSyntax newMemberDecl)
             {
-                newMethodWithTrivia = AddXmlDocComment(newMemberDecl, comment, newSourceCode);
+                newMethodWithTrivia = AddXmlDocComment(newMemberDecl, comment, newSourceCode!);
             }
 
             var newRootNode = root.ReplaceNode(methodNode, newMethodWithTrivia);
@@ -225,9 +284,9 @@ public partial class SolutionAnalyzerService
 
             // Write the updated file
             var filePath = syntaxTree.FilePath;
-            var newText = formattedRoot.ToFullString();
+            var newText2 = formattedRoot.ToFullString();
 
-            await File.WriteAllTextAsync(filePath, newText);
+            await File.WriteAllTextAsync(filePath, newText2);
 
             // Calculate new line numbers
             var newMethodInUpdated = newRootNode.DescendantNodes()


### PR DESCRIPTION
## Summary
- Adds `oldText`/`newText`/`replaceAll` parameters to `UpdateMethod` for targeted text replacement within methods
- Token-efficient alternative to passing the full method source via `newSourceCode`
- Includes validation, error messages for not-found and ambiguous matches

## Test plan
- [x] 8 new unit tests covering all edit mode paths (117 total pass)
- [x] Real-world tested on SharpOps.Examples.Calculator via live MCP server

Fixes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)