### PR TITLE
Fix: Graph staleness detection and incremental analysis

### DIFF
--- a/RoslynMcpServer.Graph/GraphAnalyzer.cs
+++ b/RoslynMcpServer.Graph/GraphAnalyzer.cs
@@ -55,6 +55,19 @@ public sealed class GraphAnalyzer
         }
 
         // Find all type declarations
+        // Track file in Files table (even for files with no type declarations)
+        if (fileHash != null)
+        {
+            await _db.UpsertFileAsync(new FileRecord
+            {
+                SolutionId = solutionId,
+                FilePath = filePath,
+                LastModified = !string.IsNullOrEmpty(document.FilePath) ? new FileInfo(document.FilePath).LastWriteTimeUtc : DateTime.UtcNow,
+                ContentHash = fileHash,
+                LastAnalyzed = DateTime.UtcNow
+            });
+        }
+
         var types = root.DescendantNodes().OfType<TypeDeclarationSyntax>();
 
         foreach (var typeDecl in types)

--- a/RoslynMcpServer.Graph/GraphDatabase.Files.cs
+++ b/RoslynMcpServer.Graph/GraphDatabase.Files.cs
@@ -120,11 +120,13 @@ public sealed partial class GraphDatabase
 
         return deletedFiles.Count;
     }
-
     /// <summary>
-    /// Removes symbols from deleted files.
+    /// Removes symbols from files that no longer exist. Pass existingFiles (set of relative paths) for accurate detection when symbols store relative paths.
     /// </summary>
-    public async Task<int> CleanupSymbolsFromDeletedFilesAsync(long solutionId)
+    /// <param name="solutionId"></param>
+    /// <param name="existingFiles"></param>
+    /// <returns></returns>
+    public async Task<int> CleanupSymbolsFromDeletedFilesAsync(long solutionId, ISet<string>? existingFiles = null)
     {
         if (_connection == null) throw new InvalidOperationException("Database not open");
 
@@ -133,7 +135,18 @@ public sealed partial class GraphDatabase
             "SELECT DISTINCT FilePath FROM Symbols WHERE SolutionId = @SolutionId AND FilePath != 'external'",
             new { SolutionId = solutionId });
 
-        var deletedPaths = symbolFilePaths.Where(p => !File.Exists(p)).ToList();
+        List<string> deletedPaths;
+        if (existingFiles != null)
+        {
+            // Use the provided set of existing files (relative paths)
+            deletedPaths = symbolFilePaths.Where(p => !existingFiles.Contains(p)).ToList();
+        }
+        else
+        {
+            // Fallback: check absolute paths on disk
+            deletedPaths = symbolFilePaths.Where(p => !File.Exists(p)).ToList();
+        }
+
         if (deletedPaths.Count == 0) return 0;
 
         var deletedCount = await _connection.ExecuteAsync(
@@ -222,15 +235,15 @@ public sealed partial class GraphDatabase
 
         return needsAnalysis;
     }
-
     /// <summary>
-    /// Computes SHA256 hash of file content (first 16 hex chars).
+    /// Computes SHA256 hash of file content (first 16 hex chars). Reads as text to ensure consistency with ComputeContentHash.
     /// </summary>
+    /// <param name="filePath"></param>
+    /// <returns></returns>
     public static string ComputeFileHash(string filePath)
     {
-        var bytes = File.ReadAllBytes(filePath);
-        var hash = SHA256.HashData(bytes);
-        return Convert.ToHexString(hash)[..16];
+        var content = File.ReadAllText(filePath);
+        return ComputeContentHash(content);
     }
 
     /// <summary>

--- a/src/RoslynTools.AddMember.cs
+++ b/src/RoslynTools.AddMember.cs
@@ -353,14 +353,13 @@ public static partial class RoslynTools
         var solutionDir = Path.GetDirectoryName(solutionPath);
         if (string.IsNullOrEmpty(solutionDir))
         {
-            return result; // Can't check freshness without solution dir
+            return result;
         }
 
-        // Compute current file hashes using relative paths (normalized to backslash)
+        // Compute current file hashes using relative paths
         var currentFileHashes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         foreach (var absolutePath in Directory.EnumerateFiles(solutionDir, "*.cs", SearchOption.AllDirectories))
         {
-            // Skip generated files and obj folder
             if (absolutePath.EndsWith(".g.cs", StringComparison.OrdinalIgnoreCase) ||
                 absolutePath.EndsWith(".designer.cs", StringComparison.OrdinalIgnoreCase) ||
                 absolutePath.Contains(Path.DirectorySeparatorChar + "obj" + Path.DirectorySeparatorChar))
@@ -368,16 +367,13 @@ public static partial class RoslynTools
                 continue;
             }
 
-            // Convert to relative path with consistent separators
             var relativePath = absolutePath.Substring(solutionDir.Length)
                 .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
                 .Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
 
             try
             {
-                // Use content-based hash (read as text) for consistency with GraphAnalyzer
-                var content = File.ReadAllText(absolutePath);
-                currentFileHashes[relativePath] = GraphDatabase.ComputeContentHash(content);
+                currentFileHashes[relativePath] = GraphDatabase.ComputeFileHash(absolutePath);
             }
             catch
             {
@@ -385,26 +381,28 @@ public static partial class RoslynTools
             }
         }
 
-        // Find stale files - only those with non-null FileHash that differs
+        // Clean up symbols from deleted files
+        var existingFiles = new HashSet<string>(currentFileHashes.Keys, StringComparer.OrdinalIgnoreCase);
+        await db.CleanupSymbolsFromDeletedFilesAsync(solutionId, existingFiles);
+
+        // Find stale files
         var staleFiles = await db.GetStaleSymbolFilesAsync(solutionId, currentFileHashes);
 
-        // Filter to only files that actually exist and have hash mismatches (not just missing from current)
         var filesToRefresh = staleFiles
             .Where(f => currentFileHashes.ContainsKey(f))
             .ToList();
 
         if (filesToRefresh.Count == 0)
         {
-            return result; // Graph is fresh
+            return result;
         }
 
         result.WasFresh = false;
         result.StaleFilesFound = filesToRefresh.Count;
 
-        // Load Roslyn solution for re-analysis
         if (_analyzerService == null)
         {
-            return result; // Can't refresh without analyzer
+            return result;
         }
 
         var roslynSolution = await SolutionAnalyzerService.LoadSolutionAsync(solutionPath);
@@ -413,7 +411,6 @@ public static partial class RoslynTools
             return result;
         }
 
-        // Re-analyze stale files (delete then re-analyze each)
         var analyzer = new GraphAnalyzer(db);
         var reanalyzedFiles = new List<string>();
 

--- a/src/RoslynTools.Graph.cs
+++ b/src/RoslynTools.Graph.cs
@@ -249,7 +249,13 @@ public static partial class RoslynTools
             RefreshedFiles = freshnessResult.ReanalyzedFiles
         };
     }
-
+    /// <summary>
+    /// Analyzes a solution and builds/updates the call graph. When incremental=true, skips files whose content hash matches the graph. Also cleans up symbols from deleted files.
+    /// </summary>
+    /// <param name="solutionPath"></param>
+    /// <param name="incremental"></param>
+    /// <param name="projectFilter"></param>
+    /// <returns></returns>
     private static async Task<GraphAnalyzeResult> AnalyzeGraphAsync(
         string solutionPath, bool incremental, string? projectFilter)
     {
@@ -271,7 +277,21 @@ public static partial class RoslynTools
             };
         }
 
+        // In incremental mode, build a lookup of known file hashes from the graph
+        Dictionary<string, string>? knownHashes = null;
+        if (incremental && !string.IsNullOrEmpty(solutionDir))
+        {
+            var allSymbols = await db.GetAllSymbolsAsync(solution.Id, projectFilter);
+            knownHashes = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var sym in allSymbols)
+            {
+                if (sym.FilePath != "external" && sym.FileHash != null)
+                    knownHashes.TryAdd(sym.FilePath, sym.FileHash);
+            }
+        }
+
         var documentsAnalyzed = 0;
+        var skippedDocuments = 0;
 
         foreach (var project in roslynSolution.Projects)
         {
@@ -284,14 +304,70 @@ public static partial class RoslynTools
             foreach (var document in project.Documents)
             {
                 if (document.FilePath == null) continue;
-                // Skip generated files
                 if (document.FilePath.EndsWith(".g.cs") || document.FilePath.EndsWith(".designer.cs"))
                     continue;
+
+                // Incremental: skip files whose hash hasn't changed
+                if (knownHashes != null && !string.IsNullOrEmpty(solutionDir))
+                {
+                    var relativePath = document.FilePath;
+                    if (document.FilePath.StartsWith(solutionDir, StringComparison.OrdinalIgnoreCase))
+                    {
+                        relativePath = document.FilePath.Substring(solutionDir.Length)
+                            .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                            .Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
+                    }
+
+                    try
+                    {
+                        var currentHash = GraphDatabase.ComputeFileHash(document.FilePath);
+
+                        // Check Symbols table first, then Files table (for files with no type declarations)
+                        if (knownHashes.TryGetValue(relativePath, out var storedHash))
+                        {
+                            if (currentHash == storedHash)
+                            {
+                                skippedDocuments++;
+                                continue;
+                            }
+                            // Stale: delete old symbols first
+                            await db.DeleteSymbolsByFileAsync(solution.Id, relativePath);
+                        }
+                        else
+                        {
+                            // Not in Symbols — check Files table (covers files with no type declarations)
+                            var fileRecord = await db.GetFileAsync(solution.Id, relativePath);
+                            if (fileRecord != null && fileRecord.ContentHash == currentHash)
+                            {
+                                skippedDocuments++;
+                                continue;
+                            }
+                        }
+                    }
+                    catch { /* can't read → re-analyze */ }
+                }
 
                 await analyzer.AnalyzeDocumentAsync(document, solution.Id, solutionDir);
                 documentsAnalyzed++;
             }
         }
+
+        // Clean up symbols from files no longer in the solution
+        var analyzedRelativePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var project in roslynSolution.Projects)
+        {
+            foreach (var doc in project.Documents)
+            {
+                if (doc.FilePath != null && !string.IsNullOrEmpty(solutionDir) &&
+                    doc.FilePath.StartsWith(solutionDir, StringComparison.OrdinalIgnoreCase))
+                {
+                    analyzedRelativePaths.Add(doc.FilePath.Substring(solutionDir.Length)
+                        .TrimStart(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar)
+                        .Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar));
+                }
+            }
+        }
+        await db.CleanupSymbolsFromDeletedFilesAsync(solution.Id, analyzedRelativePaths);
 
         await db.UpdateSolutionAnalyzedAsync(solution.Id);
 


### PR DESCRIPTION
## Summary
- Unified hash methods (ComputeFileHash now delegates to ComputeContentHash) to prevent false staleness from binary vs text encoding differences
- Implemented real incremental mode in GraphAnalyze — skips unchanged files by comparing content hashes against Symbols + Files tables
- Added deleted file cleanup to both EnsureGraphFreshAsync and GraphAnalyze
- Fixed CleanupSymbolsFromDeletedFilesAsync relative path handling
- Track file hashes in Files table even for documents with no type declarations (Program.cs, GlobalUsings, etc.)

## Test plan
- [x] 117 existing tests pass
- [x] Full analysis: 136 docs, 1931 symbols
- [x] Incremental (no changes): 0 docs
- [x] Incremental (1 file changed): 1 doc
- [x] Incremental (after sync): 0 docs

Fixes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)