### PR TITLE
Feature: Fuzzy symbol search fallback via graph database

### DIFF
--- a/Instructions/Topics/tools.md
+++ b/Instructions/Topics/tools.md
@@ -6,7 +6,7 @@ Hook blocks Read/Edit on .cs files. Use Roslyn tools instead.
 
 | Task | Tool |
 |------|------|
-| Find symbol | `FindSymbol(pattern)` |
+| Find symbol | `FindSymbol(pattern)` — fuzzy fallback via graph DB when no results found |
 | See class structure | `GetTypeMembers(typeName)` |
 | Read method | `GetMethodBody(typeName, methodName)` |
 | Edit method (full) | `UpdateMethod(typeName, methodName, newSourceCode, comment?)` |

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ MCP vs Native tools on enterprise codebase: 47% fewer tokens, 100% accuracy vs 8
 
 | Tool | Purpose |
 |------|---------|
-| `FindSymbol` | Search for types, methods, properties by name |
+| `FindSymbol` | Search for types, methods, properties by name. Fuzzy fallback via graph DB when no results found |
 | `GetReferences` | Find all usages of a symbol |
 | `GetCallers` | Find all call sites of a method |
 | `GetImplementations` | Find interface implementations |

--- a/Services/FuzzyMatcher.cs
+++ b/Services/FuzzyMatcher.cs
@@ -1,0 +1,134 @@
+using RoslynMcpServer.Graph;
+
+namespace RoslynMcpServer.Services;
+
+/// <summary>
+/// Provides fuzzy string matching utilities for symbol name suggestions.
+/// </summary>
+public static class FuzzyMatcher
+{
+    /// <summary>
+    /// Computes the Levenshtein edit distance between two strings (case-insensitive).
+    /// </summary>
+    public static int LevenshteinDistance(string a, string b)
+    {
+        if (a.Length == 0) return b.Length;
+        if (b.Length == 0) return a.Length;
+
+        var dp = new int[a.Length + 1, b.Length + 1];
+
+        for (var i = 0; i <= a.Length; i++) dp[i, 0] = i;
+        for (var j = 0; j <= b.Length; j++) dp[0, j] = j;
+
+        for (var i = 1; i <= a.Length; i++)
+        {
+            for (var j = 1; j <= b.Length; j++)
+            {
+                var cost = char.ToLowerInvariant(a[i - 1]) == char.ToLowerInvariant(b[j - 1]) ? 0 : 1;
+                dp[i, j] = Math.Min(
+                    Math.Min(dp[i - 1, j] + 1, dp[i, j - 1] + 1),
+                    dp[i - 1, j - 1] + cost);
+            }
+        }
+
+        return dp[a.Length, b.Length];
+    }
+
+    /// <summary>
+    /// Checks if pattern characters appear in order within target (case-insensitive).
+    /// Useful for matching abbreviations like "GTM" against "GetTypeMembers".
+    /// </summary>
+    public static bool IsSubsequence(string pattern, string target)
+    {
+        var pi = 0;
+        for (var ti = 0; ti < target.Length && pi < pattern.Length; ti++)
+        {
+            if (char.ToLowerInvariant(pattern[pi]) == char.ToLowerInvariant(target[ti]))
+                pi++;
+        }
+        return pi == pattern.Length;
+    }
+
+    /// <summary>
+    /// Finds symbols similar to the pattern using Levenshtein distance and subsequence matching.
+    /// Deduplicates by Name, applies a subsequence bonus, and filters by distance threshold.
+    /// </summary>
+    public static List<(string Name, string QualifiedName, int Score)> FindSimilar(
+    string pattern, IEnumerable<SymbolRecord> symbols, int maxResults = 5)
+    {
+        var maxDistance = Math.Max(3, pattern.Length / 3);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var candidates = new List<(string Name, string QualifiedName, int Score)>();
+
+        foreach (var sym in symbols)
+        {
+            if (!seen.Add(sym.Name))
+                continue;
+
+            var distance = LevenshteinDistance(pattern, sym.Name);
+            var isSubseq = IsSubsequence(pattern, sym.Name);
+            var isInitials = isSubseq && IsInitialsMatch(pattern, sym.Name);
+
+            int score;
+            if (isInitials)
+            {
+                // Initials match (e.g., "GTM" → "GetTypeMembers"): strong bonus
+                score = -pattern.Length;
+            }
+            else if (isSubseq && distance <= maxDistance)
+            {
+                // Subsequence + close edit distance: good match
+                score = distance - pattern.Length;
+            }
+            else if (distance <= maxDistance)
+            {
+                // Edit distance only
+                score = distance;
+            }
+            else if (isSubseq && sym.Name.Length <= pattern.Length * 2)
+            {
+                // Subsequence with moderate length difference (e.g., "GetTypMembers" → "GetTypeMembersAsync")
+                score = distance;
+            }
+            else
+            {
+                continue;
+            }
+
+            candidates.Add((sym.Name, sym.QualifiedName, score));
+        }
+
+        return candidates
+            .OrderBy(c => c.Score)
+            .ThenBy(c => c.Name)
+            .Take(maxResults)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Checks if the pattern matches the initials (uppercase/word-boundary letters) of the target. For example, "GTM" matches "GetTypeMembers".
+    /// </summary>
+    /// <param name="pattern"></param>
+    /// <param name="target"></param>
+    /// <returns></returns>
+    public static bool IsInitialsMatch(string pattern, string target)
+    {
+        // Extract initials: first char + every uppercase letter
+        var initials = new List<char>();
+        for (var i = 0; i < target.Length; i++)
+        {
+            if (i == 0 || char.IsUpper(target[i]))
+                initials.Add(char.ToLowerInvariant(target[i]));
+        }
+
+        if (pattern.Length > initials.Count) return false;
+
+        // Check if pattern matches a prefix of the initials
+        for (var i = 0; i < pattern.Length; i++)
+        {
+            if (char.ToLowerInvariant(pattern[i]) != initials[i])
+                return false;
+        }
+        return true;
+    }
+}

--- a/src/RoslynTools.FindSymbol.cs
+++ b/src/RoslynTools.FindSymbol.cs
@@ -1,3 +1,5 @@
+using RoslynMcpServer.Graph;
+using RoslynMcpServer.Services;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -18,7 +20,7 @@ public static partial class RoslynTools
             "FindSymbol",
             new ToolDefinition
             {
-                Description = "Searches for symbols (types, methods, properties, fields) in a .NET solution by name. Returns fully qualified names, file locations, and signatures. Much faster and more accurate than text search.",
+                Description = "Searches for symbols (types, methods, properties, fields) in a .NET solution by name. Returns fully qualified names, file locations, and signatures. Much faster and more accurate than text search. When no results are found, falls back to fuzzy matching via the graph database to suggest similar symbol names (requires prior GraphAnalyze).",
                 InputSchema = new
                 {
                     type = "object",
@@ -78,17 +80,34 @@ public static partial class RoslynTools
         var result = await _analyzerService!.SearchSymbolsAsync(
             solutionPath!, pattern, symbolKind, matchType, maxResults);
 
-        var response = await BuildFindSymbolResponseAsync(solutionPath!, result);
+        // Fuzzy fallback: when no results, suggest similar names from graph DB
+        List<string>? suggestions = null;
+        if (result.TotalFound == 0)
+        {
+            suggestions = await GetFuzzySuggestionsAsync(solutionPath!, pattern);
+        }
+
+        var response = await BuildFindSymbolResponseAsync(solutionPath!, result, suggestions);
         return CreateSuccessResponse(response, !result.Success);
     }
 
     /// <summary>
     /// Builds the response for find_symbol, including knowledge flags.
     /// </summary>
-    private static async Task<object> BuildFindSymbolResponseAsync(string solutionPath, FindSymbolResult result)
+    private static async Task<object> BuildFindSymbolResponseAsync(string solutionPath, FindSymbolResult result, List<string>? suggestions = null)
     {
         if (!result.Success || result.Symbols == null || result.Symbols.Count == 0)
         {
+            if (suggestions != null && suggestions.Count > 0)
+            {
+                return new
+                {
+                    count = 0,
+                    symbols = Array.Empty<string>(),
+                    suggestions
+                };
+            }
+
             return new
             {
                 count = 0,
@@ -113,5 +132,32 @@ public static partial class RoslynTools
             count = result.TotalFound,
             symbols = compactSymbols
         };
+    }
+
+    /// <summary>
+    /// Queries the graph database for fuzzy symbol name suggestions when FindSymbol returns no results.
+    /// </summary>
+    private static async Task<List<string>?> GetFuzzySuggestionsAsync(string solutionPath, string pattern)
+    {
+        using var db = new GraphDatabase(solutionPath);
+        if (!db.Exists()) return null;
+
+        await db.OpenAsync();
+        var solution = await db.GetSolutionAsync(solutionPath);
+        if (solution == null) return null;
+
+        var allSymbols = await db.GetAllSymbolsAsync(solution.Id);
+        if (allSymbols.Count == 0) return null;
+
+        var matches = FuzzyMatcher.FindSimilar(pattern, allSymbols);
+        if (matches.Count == 0) return null;
+
+        return matches.Select(m =>
+        {
+            var distance = FuzzyMatcher.LevenshteinDistance(pattern, m.Name);
+            var isSubseq = FuzzyMatcher.IsSubsequence(pattern, m.Name);
+            var matchType = isSubseq && distance > 3 ? "subsequence" : $"distance: {distance}";
+            return $"{m.Name} ({matchType})";
+        }).ToList();
     }
 }


### PR DESCRIPTION
## Summary
- When `FindSymbol` returns 0 results, falls back to the graph database to suggest similar symbol names
- Uses Levenshtein distance (typos), subsequence matching (partial names), and PascalCase initials matching (abbreviations)
- New `Services/FuzzyMatcher.cs` utility class with static matching methods
- Suggestions returned in a new `suggestions` field in the response

## Test plan
- [x] `dotnet build` compiles cleanly
- [x] `dotnet test` — all 117 tests pass
- [x] Real-world: `FindSymbol("GetTypMembers")` → suggests `GetTypeMembersAsync`
- [x] Real-world: `FindSymbol("GTM")` → suggests `GetTypeMembersAsync` via subsequence
- [x] Real-world: `FindSymbol("FndSymbol")` → suggests `FindSymbolAsync`
- [x] Real-world: `FindSymbol("GraphDatabase")` → normal search works, no fallback

Fixes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)