### PR TITLE
Fix: UpdateMethod edit mode line ending mismatch

### DIFF
--- a/src/SolutionAnalyzerService.UpdateMethod.cs
+++ b/src/SolutionAnalyzerService.UpdateMethod.cs
@@ -183,6 +183,13 @@ public partial class SolutionAnalyzerService
             if (oldText != null && newText != null)
             {
                 var currentSource = methodNode.ToFullString();
+
+                // Normalize line endings for cross-platform compatibility
+                // MCP JSON transport sends \n but source files may have \r\n on Windows
+                currentSource = currentSource.Replace("\r\n", "\n");
+                oldText = oldText.Replace("\r\n", "\n");
+                newText = newText.Replace("\r\n", "\n");
+
                 var occurrences = 0;
                 var idx = -1;
                 var searchFrom = 0;


### PR DESCRIPTION
## Summary
- Normalizes CRLF to LF in `currentSource`, `oldText`, and `newText` before comparison in UpdateMethod edit mode
- MCP JSON transport sends `\n` but source files may have `\r\n` on Windows, causing ordinal `IndexOf` to fail with "oldText not found"

## Test plan
- [x] `dotnet build` — compiles cleanly
- [x] `dotnet test` — all 117 tests pass
- [x] Real-world: single-line edit on `Calculator.Add` in SharpOps.Examples
- [x] Real-world: multi-line edit on `Calculator.GetCount` in SharpOps.Examples

Fixes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)