### PR TITLE
Fix: GetCallers symbolName API + graph top-level statements + isError cleanup

### DIFF
--- a/RoslynMcpServer.Graph/GraphAnalyzer.cs
+++ b/RoslynMcpServer.Graph/GraphAnalyzer.cs
@@ -77,6 +77,15 @@ public sealed class GraphAnalyzer
 
             await ProcessTypeMembersAsync(typeDecl, typeSymbol, semanticModel, solutionId, filePath, fileHash);
         }
+
+        // Handle top-level statements (C# 9+) — these produce GlobalStatementSyntax nodes
+        // at the compilation unit level, outside any TypeDeclarationSyntax.
+        // The compiler synthesizes a Program.<Main>$ method for them.
+        var globalStatements = root.ChildNodes().OfType<GlobalStatementSyntax>().ToList();
+        if (globalStatements.Count > 0)
+        {
+            await ProcessGlobalStatementsAsync(globalStatements, semanticModel, solutionId, filePath, fileHash);
+        }
     }
 
     private async Task ProcessTypeMembersAsync(
@@ -633,5 +642,58 @@ public sealed class GraphAnalyzer
         }
 
         return edges;
+    }
+
+    /// <summary>
+    /// Processes top-level statements (C# 9+) by creating a symbol for the synthesized entry point and analyzing call edges from global statements.
+    /// </summary>
+    /// <param name="globalStatements"></param>
+    /// <param name="semanticModel"></param>
+    /// <param name="solutionId"></param>
+    /// <param name="filePath"></param>
+    /// <param name="fileHash"></param>
+    private async Task ProcessGlobalStatementsAsync(
+        List<GlobalStatementSyntax> globalStatements,
+        SemanticModel semanticModel,
+        long solutionId,
+        string filePath,
+        string? fileHash)
+    {
+        // Get the synthesized entry point method (Program.<Main>$)
+        var entryPoint = semanticModel.Compilation.GetEntryPoint(default);
+        if (entryPoint == null) return;
+
+        var qualifiedName = GetQualifiedName(entryPoint);
+        var firstStatement = globalStatements[0];
+        var lineSpan = firstStatement.GetLocation().GetLineSpan();
+
+        var symbolId = await GetOrCreateSymbolAsync(new SymbolRecord
+        {
+            SolutionId = solutionId,
+            Kind = SymbolKind.Method,
+            Name = entryPoint.Name,
+            QualifiedName = qualifiedName,
+            FilePath = filePath,
+            Line = lineSpan.StartLinePosition.Line + 1,
+            Column = lineSpan.StartLinePosition.Character + 1,
+            FileHash = fileHash,
+            Status = SymbolStatus.Analyzed
+        });
+
+        // Analyze each global statement for call edges
+        var edges = new List<EdgeRecord>();
+        foreach (var globalStatement in globalStatements)
+        {
+            foreach (var node in globalStatement.DescendantNodes())
+            {
+                var nodeEdges = await AnalyzeNodeAsync(node, symbolId, solutionId, semanticModel);
+                edges.AddRange(nodeEdges);
+            }
+        }
+
+        if (edges.Count > 0)
+        {
+            await _db.InsertEdgesAsync(edges);
+        }
     }
 }

--- a/RoslynMcpServer.Tests/Services/GetCallersTests.cs
+++ b/RoslynMcpServer.Tests/Services/GetCallersTests.cs
@@ -19,9 +19,7 @@ public class GetCallersTests
         // Act
         var result = await SolutionAnalyzerService.GetCallersAsync(
             fakePath,
-            @"C:\some\file.cs",
-            line: 10,
-            column: 5);
+            "SomeMethod");
 
         // Assert
         Assert.False(result.Success);
@@ -33,7 +31,7 @@ public class GetCallersTests
     /// Issue: #7
     /// </summary>
     [Fact]
-    public async Task GetCallersAsync_WithInvalidFile_ReturnsError()
+    public async Task GetCallersAsync_WithNonExistentSymbol_ReturnsEmpty()
     {
         // Arrange
         var service = new SolutionAnalyzerService();
@@ -43,13 +41,11 @@ public class GetCallersTests
         // Act
         var result = await SolutionAnalyzerService.GetCallersAsync(
             solutionPath,
-            @"C:\nonexistent\file.cs",
-            line: 10,
-            column: 5);
+            "NonExistentMethodXyz123");
 
         // Assert
-        Assert.False(result.Success);
-        Assert.Contains("not found", result.Error, StringComparison.OrdinalIgnoreCase);
+        Assert.True(result.Success);
+        Assert.Equal(0, result.TotalCallers);
     }
 
     /// <summary>

--- a/src/RoslynTools.Callers.cs
+++ b/src/RoslynTools.Callers.cs
@@ -6,10 +6,8 @@ namespace RoslynMcpServer;
 
 public static partial class RoslynTools
 {
-    private static readonly string[] definitionArray1 = ["filePath", "line", "column"];
-
     /// <summary>
-    /// Finds all callers of a method at a given position.
+    /// Finds all callers of a method/property by name.
     /// Uses graph cache when available, with automatic staleness detection and refresh.
     /// </summary>
     private static void RegisterGetCallersTool(McpServer server)
@@ -18,28 +16,16 @@ public static partial class RoslynTools
             "GetCallers",
             new ToolDefinition
             {
-                Description = "Finds all callers of a method/property at a given file position. Unlike get_references, this returns only actual call sites - not declarations, docs, or type references. Essential for understanding execution flow and impact analysis before refactoring.",
+                Description = "Finds all callers of a method/property by name. Unlike get_references, this returns only actual call sites - not declarations, docs, or type references. Essential for understanding execution flow and impact analysis before refactoring.",
                 InputSchema = new
                 {
                     type = "object",
                     properties = new
                     {
-                        filePath = new
+                        symbolName = new
                         {
                             type = "string",
-                            description = "Absolute path to the source file containing the method"
-                        },
-                        line = new
-                        {
-                            type = "integer",
-                            description = "Line number (1-based) where the method is located",
-                            minimum = 1
-                        },
-                        column = new
-                        {
-                            type = "integer",
-                            description = "Column number (1-based) where the method is located",
-                            minimum = 1
+                            description = "Name of the method/property to find callers of. Supports: 'MethodName', 'Type.Method', or 'Namespace.Type.Method'"
                         },
                         maxResults = new
                         {
@@ -65,7 +51,7 @@ public static partial class RoslynTools
                             description = "Filter by file path. Supports wildcards (*). Example: '*Service.cs'"
                         }
                     },
-                    required = new[] { "filePath", "line", "column" }
+                    required = new[] { "symbolName" }
                 },
                 Annotations = new ToolAnnotations
                 {
@@ -84,13 +70,7 @@ public static partial class RoslynTools
         var (solutionPath, solutionError) = GetSolutionPathOrError();
         if (solutionError != null) return solutionError;
 
-        if (!TryGetRequiredString(args, "filePath", out var filePath, out var error))
-            return error!;
-
-        if (!TryGetRequiredInt(args, "line", 1, out var line, out error))
-            return error!;
-
-        if (!TryGetRequiredInt(args, "column", 1, out var column, out error))
+        if (!TryGetRequiredString(args, "symbolName", out var symbolName, out var error))
             return error!;
 
         var maxResults = GetOptionalInt(args, "maxResults", 100);
@@ -104,9 +84,9 @@ public static partial class RoslynTools
         try
         {
             var graphResult = await TryGetCallersFromGraphAsync(
-                solutionPath!, filePath, line, column, maxResults, offset, projectFilter, fileFilter);
+                solutionPath!, symbolName, maxResults, offset, projectFilter, fileFilter);
 
-            if (graphResult != null)
+            if (graphResult != null && graphResult.TotalCallers > 0)
             {
                 result = graphResult;
             }
@@ -118,9 +98,10 @@ public static partial class RoslynTools
 
         if (result == null)
         {
-            // Fall back to live analysis
+            // Fall back to live analysis when graph is unavailable OR returns 0 callers.
+            // Graph may miss callers (e.g., stale graph), so live Roslyn is the source of truth.
             var liveResult = await SolutionAnalyzerService.GetCallersAsync(
-                solutionPath!, filePath, line, column, maxResults, offset, projectFilter, fileFilter);
+                solutionPath!, symbolName, maxResults, offset, projectFilter, fileFilter);
 
             result = new GetCallersResult
             {
@@ -142,7 +123,7 @@ public static partial class RoslynTools
                 {
                     new { type = "text", text = result.Error ?? "Failed to find callers" }
                 },
-                isError = true
+                isError = false
             };
         }
 
@@ -176,9 +157,7 @@ public static partial class RoslynTools
     /// </summary>
     private static async Task<GetCallersResult?> TryGetCallersFromGraphAsync(
         string solutionPath,
-        string filePath,
-        int line,
-        int column,
+        string symbolName,
         int maxResults,
         int offset,
         string? projectFilter,
@@ -194,16 +173,23 @@ public static partial class RoslynTools
         // Ensure graph is fresh before querying (blocking)
         var freshnessResult = await EnsureGraphFreshAsync(db, solution.Id, solutionPath);
 
-        // Get the symbol's qualified name from Roslyn
-        var roslynSolution = await SolutionAnalyzerService.LoadSolutionAsync(solutionPath);
-        if (roslynSolution == null) return null;
+        // Look up symbol in graph by name
+        var searchResult = await db.FindSymbolAsync(solution.Id, symbolName);
+        if (searchResult.Symbol == null)
+        {
+            // Return error with candidates if ambiguous
+            if (searchResult.Candidates?.Count > 0)
+            {
+                return new GetCallersResult
+                {
+                    Success = false,
+                    Error = searchResult.Error
+                };
+            }
+            return null; // Not found, fall back to live
+        }
 
-        var qualifiedName = await SolutionAnalyzerService.GetSymbolQualifiedNameAsync(solutionPath, filePath, line, column);
-        if (string.IsNullOrEmpty(qualifiedName)) return null;
-
-        // Look up symbol in graph
-        var symbol = await db.GetSymbolByQualifiedNameAsync(solution.Id, qualifiedName);
-        if (symbol == null) return null;
+        var symbol = searchResult.Symbol;
 
         // Get callers from fresh graph
         var callers = await db.GetCallersAsync(symbol.Id);
@@ -242,12 +228,12 @@ public static partial class RoslynTools
             .ToList();
 
         // Track for visualization sync
-        LastSymbolTracker.Track(solutionPath, qualifiedName, "member");
+        LastSymbolTracker.Track(solutionPath, symbol.QualifiedName, "member");
 
         return new GetCallersResult
         {
             Success = true,
-            Symbol = qualifiedName,
+            Symbol = symbol.QualifiedName,
             TotalCallers = totalCallers,
             ReturnedCount = paginatedCallers.Count,
             Source = freshnessResult.FilesReanalyzed > 0 ? "graph+refresh" : "graph",

--- a/src/RoslynTools.Graph.cs
+++ b/src/RoslynTools.Graph.cs
@@ -525,7 +525,7 @@ public static partial class RoslynTools
         return new
         {
             content = new[] { new { type = "text", text = message } },
-            isError = true
+            isError = false
         };
     }
 

--- a/src/RoslynTools.GraphImpact.cs
+++ b/src/RoslynTools.GraphImpact.cs
@@ -595,7 +595,7 @@ public static partial class RoslynTools
         return new
         {
             content = new[] { new { type = "text", text = message } },
-            isError = true
+            isError = false
         };
     }
 }

--- a/src/RoslynTools.Implementations.cs
+++ b/src/RoslynTools.Implementations.cs
@@ -83,7 +83,7 @@ public static partial class RoslynTools
                         {
                             new { type = "text", text = result.Error ?? "Failed to find implementations" }
                         },
-                        isError = true
+                        isError = false
                     };
                 }
 

--- a/src/RoslynTools.MethodBody.cs
+++ b/src/RoslynTools.MethodBody.cs
@@ -100,7 +100,7 @@ public static partial class RoslynTools
                         {
                             new { type = "text", text = JsonSerializer.Serialize(errorResponse, JsonOptions) }
                         },
-                        isError = true
+                        isError = false
                     };
                 }
 

--- a/src/RoslynTools.References.cs
+++ b/src/RoslynTools.References.cs
@@ -131,7 +131,7 @@ public static partial class RoslynTools
                         {
                             new { type = "text", text = result.Error ?? "Failed to find references" }
                         },
-                        isError = true
+                        isError = false
                     };
                 }
 

--- a/src/RoslynTools.TypeMembers.cs
+++ b/src/RoslynTools.TypeMembers.cs
@@ -98,7 +98,7 @@ public static partial class RoslynTools
                         {
                             new { type = "text", text = JsonSerializer.Serialize(result, JsonOptions) }
                         },
-                        isError = true
+                        isError = false
                     };
                 }
 

--- a/src/SolutionAnalyzerService.Callers.cs
+++ b/src/SolutionAnalyzerService.Callers.cs
@@ -11,9 +11,7 @@ public partial class SolutionAnalyzerService
     /// </summary>
     public static async Task<GetCallersResult> GetCallersAsync(
         string solutionPath,
-        string filePath,
-        int line,
-        int column,
+        string symbolName,
         int maxResults = 100,
         int offset = 0,
         string? projectFilter = null,
@@ -30,15 +28,6 @@ public partial class SolutionAnalyzerService
             };
         }
 
-        if (!File.Exists(filePath))
-        {
-            return new GetCallersResult
-            {
-                Success = false,
-                Error = $"Source file not found: {filePath}"
-            };
-        }
-
         using var workspace = CreateWorkspace();
 
         try
@@ -46,65 +35,65 @@ public partial class SolutionAnalyzerService
             Console.Error.WriteLine($"Loading solution: {solutionPath}");
             var solution = await workspace.OpenSolutionAsync(solutionPath);
 
-            // Find the document
-            var normalizedPath = Path.GetFullPath(filePath);
-            var document = solution.Projects
-                .SelectMany(p => p.Documents)
-                .FirstOrDefault(d => string.Equals(
-                    Path.GetFullPath(d.FilePath ?? ""),
-                    normalizedPath,
-                    StringComparison.OrdinalIgnoreCase));
+            // Parse symbolName: could be "Method", "Type.Method", or "Namespace.Type.Method"
+            // Extract the short name for SymbolFinder (last segment before any parentheses)
+            var nameWithoutParams = symbolName.Contains('(')
+                ? symbolName[..symbolName.IndexOf('(')]
+                : symbolName;
+            var segments = nameWithoutParams.Split('.');
+            var shortName = segments[^1];
 
-            if (document == null)
+            // Find declarations matching the short name across all projects
+            var declarations = new List<ISymbol>();
+            foreach (var project in solution.Projects)
+            {
+                var projectDecls = await SymbolFinder.FindDeclarationsAsync(
+                    project, shortName, ignoreCase: false);
+                declarations.AddRange(projectDecls);
+            }
+
+            // Filter to callable symbols (methods, properties, events)
+            var callables = declarations
+                .Where(s => s is IMethodSymbol or IPropertySymbol or IEventSymbol)
+                .ToList();
+
+            if (callables.Count == 0)
             {
                 return new GetCallersResult
                 {
-                    Success = false,
-                    Error = $"File not found in solution: {filePath}"
+                    Success = true,
+                    Symbol = symbolName,
+                    TotalCallers = 0,
+                    ReturnedCount = 0,
+                    Callers = []
                 };
             }
 
-            // Get semantic model and find symbol at position
-            var semanticModel = await document.GetSemanticModelAsync();
-            if (semanticModel == null)
+            // Match against the full symbolName for precision
+            ISymbol? targetSymbol = null;
+            foreach (var sym in callables)
             {
-                return new GetCallersResult
+                var qualifiedName = sym.ContainingType != null
+                    ? $"{sym.ContainingType.Name}.{sym.Name}"
+                    : sym.Name;
+                var fullQualifiedName = sym.ToDisplayString();
+
+                if (string.Equals(qualifiedName, nameWithoutParams, StringComparison.Ordinal) ||
+                    string.Equals(fullQualifiedName, nameWithoutParams, StringComparison.Ordinal) ||
+                    string.Equals(sym.Name, nameWithoutParams, StringComparison.Ordinal))
                 {
-                    Success = false,
-                    Error = "Failed to get semantic model"
-                };
+                    targetSymbol = sym;
+                    break;
+                }
             }
 
-            // Convert 1-based line/column to 0-based position
-            var text = await document.GetTextAsync();
-            var position = text.Lines[line - 1].Start + (column - 1);
+            // If no exact match, take first callable
+            targetSymbol ??= callables[0];
 
-            // Use tolerant symbol finder (Issue #68)
-            var symbol = await FindSymbolAtPositionWithToleranceAsync(semanticModel, position, workspace);
-
-            if (symbol == null)
-            {
-                return new GetCallersResult
-                {
-                    Success = false,
-                    Error = $"No symbol found at {filePath}:{line}:{column}"
-                };
-            }
-
-            // Only methods, properties, and events can have callers
-            if (symbol is not (IMethodSymbol or IPropertySymbol or IEventSymbol))
-            {
-                return new GetCallersResult
-                {
-                    Success = false,
-                    Error = $"Symbol '{symbol.Name}' is a {symbol.Kind}, not a method/property/event. Only callable symbols have callers."
-                };
-            }
-
-            Console.Error.WriteLine($"Finding callers of: {symbol.ToDisplayString()}");
+            Console.Error.WriteLine($"Finding callers of: {targetSymbol.ToDisplayString()}");
 
             // Find all callers
-            var callers = await SymbolFinder.FindCallersAsync(symbol, solution);
+            var callers = await SymbolFinder.FindCallersAsync(targetSymbol, solution);
             var callerList = callers.ToList();
 
             // Flatten to individual call locations
@@ -177,11 +166,11 @@ public partial class SolutionAnalyzerService
             Console.Error.WriteLine($"Found {totalAfterFilters} callers (returning {results.Count})");
 
             // Build symbol signature
-            var symbolSignature = symbol.ContainingType != null
-                ? $"{symbol.ContainingType.Name}.{symbol.Name}"
-                : symbol.Name;
+            var symbolSignature = targetSymbol.ContainingType != null
+                ? $"{targetSymbol.ContainingType.Name}.{targetSymbol.Name}"
+                : targetSymbol.Name;
 
-            if (symbol is IMethodSymbol method)
+            if (targetSymbol is IMethodSymbol method)
             {
                 var paramTypes = string.Join(", ", method.Parameters.Select(p => p.Type.Name));
                 symbolSignature += $"({paramTypes})";


### PR DESCRIPTION
## Summary
- Replace `filePath/line/column` with `symbolName` parameter — e.g., `GetCallers(symbolName: "TaskBoard.AddTask")`
- Add `ProcessGlobalStatementsAsync` to graph analyzer for C# 9+ top-level statements (fixes 0-caller bug)
- Fall back to live Roslyn when graph returns 0 callers (defensive)
- Change `isError=true` → `isError=false` for all read-only query tools to prevent sibling MCP tool call cancellation

## Test plan
- [x] `dotnet test` — 117 tests pass
- [x] Real-world: `GetCallers(symbolName: "TaskBoard.AddTask")` returns 5 callers from Program.cs top-level statements
- [x] Real-world: `GetCallers(symbolName: "GetQualifiedName")` returns 6 callers across GraphAnalyzer
- [x] Real-world: `GetCallers(symbolName: "NonExistentMethod")` returns 0 callers (no error, no sibling cancellation)
- [ ] Code owner verification on larger solutions

Fixes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)